### PR TITLE
swift6: Add Sendable conformances to protocol types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -180,7 +180,7 @@ var targets: [PackageDescription.Target] = [
         exclude: [
             "README.md"
         ],
-        swiftSettings: [.swiftLanguageMode(.v5)]
+        swiftSettings: [.swiftLanguageMode(.v6)]
     ),
 ]
 

--- a/Sources/DistributedActorsConcurrencyHelpers/lock.swift
+++ b/Sources/DistributedActorsConcurrencyHelpers/lock.swift
@@ -37,6 +37,9 @@ import Glibc
 /// This object provides a lock on top of a single `pthread_mutex_t`. This kind
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO.
+// @unchecked Sendable: wraps a single pthread_mutex_t. All state mutation goes through
+// lock()/unlock(), which are the only entry points to the underlying primitive. The pointer
+// is allocated at init and deallocated at deinit — never shared or mutated otherwise.
 @available(*, noasync, message: "Locks are bad in async code; If you truly must, use DispatchSemaphore")
 public final class Lock: @unchecked Sendable {
     fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)
@@ -107,7 +110,9 @@ extension Lock {
 ///
 /// This class provides a convenience addition to `Lock`: it provides the ability to wait
 /// until the state variable is set to a specific value to acquire the lock.
-public final class ConditionLock<T: Equatable>: @unchecked Sendable where T: Sendable {
+// @unchecked Sendable: all access to _value goes through the pthread_mutex_t in `mutex`.
+// T must be Sendable because instances escape across concurrency domains via the `value` property.
+public final class ConditionLock<T: Equatable & Sendable>: @unchecked Sendable {
     private var _value: T
     private let mutex: Lock
     private let cond: UnsafeMutablePointer<pthread_cond_t> = UnsafeMutablePointer.allocate(capacity: 1)

--- a/Sources/DistributedActorsConcurrencyHelpers/lock.swift
+++ b/Sources/DistributedActorsConcurrencyHelpers/lock.swift
@@ -38,7 +38,7 @@ import Glibc
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO.
 @available(*, noasync, message: "Locks are bad in async code; If you truly must, use DispatchSemaphore")
-public final class Lock {
+public final class Lock: @unchecked Sendable {
     fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> = UnsafeMutablePointer.allocate(capacity: 1)
 
     /// Create a new lock.
@@ -107,7 +107,7 @@ extension Lock {
 ///
 /// This class provides a convenience addition to `Lock`: it provides the ability to wait
 /// until the state variable is set to a specific value to acquire the lock.
-public final class ConditionLock<T: Equatable> {
+public final class ConditionLock<T: Equatable>: @unchecked Sendable where T: Sendable {
     private var _value: T
     private let mutex: Lock
     private let cond: UnsafeMutablePointer<pthread_cond_t> = UnsafeMutablePointer.allocate(capacity: 1)

--- a/Sources/DistributedCluster/ActorID.swift
+++ b/Sources/DistributedCluster/ActorID.swift
@@ -123,6 +123,7 @@ extension ClusterSystem {
     /// it shall include its local system's address. When using Codable serialization this is done automatically,
     /// and when implementing custom serializers the `Serialization.Context` should be used to access the node address
     /// to include while serializing the address.
+    // @unchecked required: contains DistributedActorContext (class) and ActorMetadata (class with lock-based thread safety)
     public struct ActorID: @unchecked Sendable {
         /// Knowledge about a node being `local` is purely an optimization, and should not be relied on by actual code anywhere.
         /// It is on purpose not exposed to end-user code as well, and must remain so to not break the location transparency promises made by the runtime.

--- a/Sources/DistributedCluster/ActorID.swift
+++ b/Sources/DistributedCluster/ActorID.swift
@@ -123,7 +123,7 @@ extension ClusterSystem {
     /// it shall include its local system's address. When using Codable serialization this is done automatically,
     /// and when implementing custom serializers the `Serialization.Context` should be used to access the node address
     /// to include while serializing the address.
-    // @unchecked required: contains DistributedActorContext (class) and ActorMetadata (class with lock-based thread safety)
+    // @unchecked required: contains DistributedActorContext (class) and ActorMetadata (class using DispatchSemaphore for thread-safe mutation)
     public struct ActorID: @unchecked Sendable {
         /// Knowledge about a node being `local` is purely an optimization, and should not be relied on by actual code anywhere.
         /// It is on purpose not exposed to end-user code as well, and must remain so to not break the location transparency promises made by the runtime.

--- a/Sources/DistributedCluster/ActorMessages.swift
+++ b/Sources/DistributedCluster/ActorMessages.swift
@@ -120,7 +120,7 @@ public struct ErrorEnvelope: Error, Codable {
     }
 }
 
-public struct BestEffortStringError: Error, Codable, Equatable, CustomStringConvertible {
+public struct BestEffortStringError: Error, Codable, Equatable, Sendable, CustomStringConvertible {
     let representation: String
 
     public var description: String {

--- a/Sources/DistributedCluster/Cluster/Cluster+Member.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Member.swift
@@ -20,7 +20,7 @@ extension Cluster {
     ///
     /// It carries `Cluster.MemberStatus` and reachability information.
     /// Its identity is the underlying `Cluster.Node`, other fields are not taken into account when comparing members.
-    public struct Member: Hashable {
+    public struct Member: Sendable, Hashable {
         /// Unique node of this cluster member.
         public let node: Cluster.Node
 
@@ -163,7 +163,7 @@ extension Cluster.Member: Codable {
 
 extension Cluster {
     /// Describes the status of a member within the clusters lifecycle.
-    public enum MemberStatus: String, CaseIterable, Comparable {
+    public enum MemberStatus: String, Sendable, CaseIterable, Comparable {
         public static var allCases: [MemberStatus] {
             [.joining, .up, .leaving, .down, .removed]
         }
@@ -296,7 +296,7 @@ extension Cluster {
     /// and `.unreachable` states multiple times during the lifetime of a member.
     ///
     /// - SeeAlso: `SWIM` for a distributed failure detector implementation which may issue unreachable events.
-    public enum MemberReachability: String, Equatable {
+    public enum MemberReachability: String, Sendable, Equatable {
         /// The member is reachable and responding to failure detector probing properly.
         case reachable
         /// Failure detector has determined this node as not reachable.

--- a/Sources/DistributedCluster/Cluster/Cluster+Membership.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Membership.swift
@@ -33,7 +33,7 @@ extension Cluster {
     /// ### Member state transitions
     /// Members can only move "forward" along their status lifecycle, refer to ``Cluster/MemberStatus``
     /// docs for a diagram of legal transitions.
-    public struct Membership: ExpressibleByArrayLiteral {
+    public struct Membership: Sendable, ExpressibleByArrayLiteral {
         public typealias ArrayLiteralElement = Cluster.Member
 
         /// Initialize an empty membership (with no members).

--- a/Sources/DistributedCluster/Props.swift
+++ b/Sources/DistributedCluster/Props.swift
@@ -122,7 +122,9 @@ public struct _Props: @unchecked Sendable {
 /// These props must be used during `_spawn` which happens on `actorReady`.
 ///
 /// This is somewhat of a relict of ActorRef infrastructure and should eventually be removed.
-// @unchecked required: contains _Props which is @unchecked Sendable
+// Phase 2: @unchecked required: stores _Props, which is itself @unchecked Sendable because it holds
+// ActorMetadata (class) and _DispatcherProps (contains non-Sendable DispatchQueue/EventLoopGroup).
+// Address the root cause in _Props (and ActorMetadata) first.
 struct _PropsShuttle: @unchecked Sendable, Codable {
     let props: _Props
     init(props: _Props) {

--- a/Sources/DistributedCluster/Props.swift
+++ b/Sources/DistributedCluster/Props.swift
@@ -29,6 +29,7 @@ import NIO
 /// For example, a skull would be a classic example of a "prop" used while performing the William Shakespeare's
 /// Hamlet Act III, scene 1, saying "To be, or not to be, that is the question: [...]." In the same sense,
 /// props for Swift Distributed Actors are accompanying objects/settings, which help the actor perform its duties.
+// @unchecked required: contains ActorMetadata (class) and _DispatcherProps (holds non-Sendable DispatchQueue/EventLoopGroup)
 public struct _Props: @unchecked Sendable {
     internal var dispatcher: _DispatcherProps = .default
 
@@ -121,6 +122,7 @@ public struct _Props: @unchecked Sendable {
 /// These props must be used during `_spawn` which happens on `actorReady`.
 ///
 /// This is somewhat of a relict of ActorRef infrastructure and should eventually be removed.
+// @unchecked required: contains _Props which is @unchecked Sendable
 struct _PropsShuttle: @unchecked Sendable, Codable {
     let props: _Props
     init(props: _Props) {

--- a/Sources/DistributedCluster/Receptionist/DistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/DistributedReceptionist.swift
@@ -381,6 +381,9 @@ internal final class DistributedReceptionistStorage {
 // ==== ----------------------------------------------------------------------------------------------------------------
 
 /// Represents a local subscription (for `receptionist.subscribe`) for a specific key.
+/// @unchecked Sendable: This class is always accessed from within the owning actor (OpLogDistributedReceptionist).
+/// The `seenActorRegistrations` mutable state is only modified by that single actor. The `onNext` closure is
+/// marked `@Sendable`. Cannot be a struct due to identity semantics (ObjectIdentifier-based subscriptionID).
 internal final class AnyDistributedReceptionListingSubscription: Hashable, @unchecked Sendable, CustomStringConvertible {
     let subscriptionID: ObjectIdentifier
     let key: AnyDistributedReceptionKey

--- a/Sources/DistributedCluster/Receptionist/Receptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/Receptionist.swift
@@ -359,6 +359,9 @@ extension _ActorRef: _ReceptionistGuest {
 ///     - `Receptionist.Register`
 ///     - `Receptionist.Subscribe`
 /// INTERNAL API
+/// @unchecked Sendable: Base class for receptionist message hierarchy. Must be a class for Codable
+/// inheritance (Register, Lookup, Subscribe are generic subclasses). The base class has no mutable state;
+/// subclasses carry immutable references (actor refs, keys) that are themselves safe to share.
 public class _ReceptionistMessage: Codable, @unchecked Sendable {}
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedCluster/Receptionist/Receptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/Receptionist.swift
@@ -359,9 +359,10 @@ extension _ActorRef: _ReceptionistGuest {
 ///     - `Receptionist.Register`
 ///     - `Receptionist.Subscribe`
 /// INTERNAL API
-/// @unchecked Sendable: Base class for receptionist message hierarchy. Must be a class for Codable
-/// inheritance (Register, Lookup, Subscribe are generic subclasses). The base class has no mutable state;
-/// subclasses carry immutable references (actor refs, keys) that are themselves safe to share.
+//// @unchecked Sendable: Base class for receptionist message hierarchy. Must be a class for subclassing
+// by _AnyRegister, _Lookup, _Subscribe, and _ReceptionistDelayedListingFlushTick. The base class has
+// no stored state; subclasses use `let` bindings for stored properties. @unchecked Sendable is required
+// because the class hierarchy cannot satisfy checked Sendable via subclassing.
 public class _ReceptionistMessage: Codable, @unchecked Sendable {}
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedCluster/Scheduler.swift
+++ b/Sources/DistributedCluster/Scheduler.swift
@@ -55,7 +55,7 @@ final class FlagCancelable: Cancelable, @unchecked Sendable {
     }
 }
 
-extension DispatchWorkItem: Cancelable {
+extension DispatchWorkItem: @retroactive Cancelable {
     @usableFromInline
     var isCanceled: Bool {
         self.isCancelled

--- a/Sources/DistributedCluster/Scheduler.swift
+++ b/Sources/DistributedCluster/Scheduler.swift
@@ -38,6 +38,8 @@ internal protocol Scheduler: Sendable {
     func schedule<Message>(initialDelay: Duration, interval: Duration, receiver: _ActorRef<Message>, message: Message) -> Cancelable
 }
 
+// @unchecked Sendable: flag is a ManagedAtomic<Bool> which is itself Sendable and provides
+// sequentially-consistent atomic operations. No other mutable state.
 final class FlagCancelable: Cancelable, @unchecked Sendable {
     private let flag: ManagedAtomic<Bool> = .init(false)
 

--- a/Sources/DistributedCluster/Scheduler.swift
+++ b/Sources/DistributedCluster/Scheduler.swift
@@ -17,7 +17,7 @@ import Dispatch
 import DistributedActorsConcurrencyHelpers
 
 @usableFromInline
-protocol Cancelable {
+protocol Cancelable: Sendable {
     /// Attempts to cancel the cancellable. Returns true when successful, or false
     /// when unsuccessful, or it was already cancelled.
     func cancel()

--- a/Sources/DistributedCluster/Version.swift
+++ b/Sources/DistributedCluster/Version.swift
@@ -16,7 +16,7 @@ extension ClusterSystem {
     /// Version advertised to other nodes while joining the cluster.
     ///
     /// Can be used to determine wire of feature compatibility of nodes joining a cluster.
-    public struct Version: Equatable, CustomStringConvertible {
+    public struct Version: Sendable, Equatable, CustomStringConvertible {
         /// Exact semantics of the reserved field remain to be defined.
         public var reserved: UInt8
         public var major: UInt8

--- a/Sources/DistributedCluster/_Signals.swift
+++ b/Sources/DistributedCluster/_Signals.swift
@@ -68,6 +68,10 @@ public enum _Signals {
     /// explaining the reason for an actor having terminated.
     ///
     /// - SeeAlso: `_ChildTerminated` which is sent specifically to a parent-actor once its child has terminated.
+    /// @unchecked Sendable: This class hierarchy uses `open` for transport extensibility (custom transports
+    /// may subclass to carry additional termination info). All stored properties (id, existenceConfirmed,
+    /// nodeTerminated) are immutable `let` bindings, making instances safe to share across concurrency domains.
+    /// The only known subclass is `_ChildTerminated` (final), which adds one immutable optional field.
     open class Terminated: @unchecked Sendable, _Signal, CustomStringConvertible {
         /// Address of the terminated actor.
         public let id: ActorID


### PR DESCRIPTION
## Summary

- Adds `Sendable` requirements and conformances to protocol types in the distributed cluster layer
- Stacked on `swift6/value-types`

## Stack

1. `swift6/concurrency-helpers` — Sendable on concurrency helpers
2. `swift6/value-types` — Sendable on value types
3. **This PR** — `swift6/protocols`: Sendable on protocol types
4. `swift6/serialization` — Sendable on serialization types

## Test plan

- [ ] `swift build` passes (with TBD workaround)
- [ ] No regressions from parent branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)