### PR TITLE
chore: Make ActorMetadata @unchecked Sendable, migrate DispatchSemaphore to Lock (Phase 2)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ var targets: [PackageDescription.Target] = [
             .product(name: "Backtrace", package: "swift-backtrace"),
             .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         ],
-        swiftSettings: [.swiftLanguageMode(.v5)]
+        swiftSettings: [.swiftLanguageMode(.v6)]
     ),
 
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/Sources/DistributedCluster/ActorContext.swift
+++ b/Sources/DistributedCluster/ActorContext.swift
@@ -241,7 +241,13 @@ public class _ActorContext<Message: Codable> {  // TODO(sendable): NOTSendable
         _AsyncResult.withTimeout(after: timeout)._onComplete { [weak selfRef = self.myself._unsafeUnwrapCell] result in
             selfRef?.sendSystemMessage(.resume(result.map { $0 }))
         }
-        return .suspend(handler: continuation)
+        // The continuation runs synchronously in the actor mailbox context, so it is safe
+        // to bridge across the @Sendable boundary.
+        nonisolated(unsafe) let unsafeContinuation = continuation
+        let sendableHandler: @Sendable (Result<AR.Value, Error>) throws -> _Behavior<Message> = { result in
+            try unsafeContinuation(result)
+        }
+        return .suspend(handler: sendableHandler)
     }
 
     /// ***CAUTION***: This functionality should be used with extreme caution, as it will

--- a/Sources/DistributedCluster/ActorLogging.swift
+++ b/Sources/DistributedCluster/ActorLogging.swift
@@ -305,7 +305,7 @@ extension Logger.MetadataValue {
     }
 }
 
-struct CustomPrettyStringConvertibleMetadataValue: CustomStringConvertible {
+struct CustomPrettyStringConvertibleMetadataValue: CustomStringConvertible, @unchecked Sendable {
     let value: CustomPrettyStringConvertible
 
     init(_ value: CustomPrettyStringConvertible) {
@@ -330,7 +330,7 @@ extension Optional where Wrapped == Logger.MetadataValue {
 /// Delays rendering of metadata value (e.g. into a string)
 ///
 /// NOT thread-safe, so all access should be guarded some synchronization method, e.g. only access from an Actor.
-internal class LazyMetadataBox: CustomStringConvertible {
+internal class LazyMetadataBox: CustomStringConvertible, @unchecked Sendable {
     private var lazyValue: (() -> CustomStringConvertible)?
     private var _value: String?
 

--- a/Sources/DistributedCluster/ActorMetadata.swift
+++ b/Sources/DistributedCluster/ActorMetadata.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Dispatch
 import Distributed
+import DistributedActorsConcurrencyHelpers
 
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: ActorMetadata
@@ -81,9 +81,12 @@ extension ActorMetadataKeys {
 }
 
 /// Container of tags a concrete actor identity was tagged with.
+///
+/// - Concurrency: `@unchecked Sendable` because `_storage` is mutable but all access
+///   is serialized through `lock` (a pthread-based `Lock` from DistributedActorsConcurrencyHelpers).
 @dynamicMemberLookup
-public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConvertible {
-    internal let lock = DispatchSemaphore(value: 1)
+public final class ActorMetadata: @unchecked Sendable, CustomStringConvertible, CustomDebugStringConvertible {
+    internal let lock = Lock()
 
     // We still might re-think how we represent the storage.
     private var _storage: [String: Sendable & Codable] = [:]
@@ -93,22 +96,22 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
     }
 
     public var count: Int {
-        self.lock.wait()
-        defer { lock.signal() }
+        self.lock.lock()
+        defer { lock.unlock() }
 
         return self._storage.count
     }
 
     public var isEmpty: Bool {
-        self.lock.wait()
-        defer { lock.signal() }
+        self.lock.lock()
+        defer { lock.unlock() }
 
         return self._storage.isEmpty
     }
 
     public func remove<Value: Sendable & Codable>(forKey key: ActorMetadataKeys.Key<Value>) -> Value? {
-        self.lock.wait()
-        defer { lock.signal() }
+        self.lock.lock()
+        defer { lock.unlock() }
 
         guard let v = self._storage.removeValue(forKey: key.id) else {
             return nil
@@ -117,8 +120,8 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
     }
 
     func copy() -> ActorMetadata {
-        self.lock.wait()
-        defer { lock.signal() }
+        self.lock.lock()
+        defer { lock.unlock() }
 
         let c = ActorMetadata()
         for (k, v) in self._storage {
@@ -128,15 +131,15 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
     }
 
     func clear() {
-        self.lock.wait()
-        defer { lock.signal() }
+        self.lock.lock()
+        defer { lock.unlock() }
         self._storage = [:]
     }
 
     public subscript<Value>(dynamicMember dynamicMember: KeyPath<ActorMetadataKeys, ActorMetadataKeys.Key<Value>>) -> Value? {
         get {
-            self.lock.wait()
-            defer { lock.signal() }
+            self.lock.lock()
+            defer { lock.unlock() }
 
             let key = ActorMetadataKeys.__instance[keyPath: dynamicMember]
             let id = key.id
@@ -146,8 +149,8 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
             return v as? Value
         }
         set {
-            self.lock.wait()
-            defer { lock.signal() }
+            self.lock.lock()
+            defer { lock.unlock() }
 
             let key = ActorMetadataKeys.__instance[keyPath: dynamicMember]
             let id = key.id
@@ -160,8 +163,8 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
 
     subscript(_ id: String) -> (any Sendable & Codable)? {
         get {
-            self.lock.wait()
-            defer { lock.signal() }
+            self.lock.lock()
+            defer { lock.unlock() }
 
             if let value = self._storage[id] {
                 return value
@@ -170,8 +173,8 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
             }
         }
         set {
-            self.lock.wait()
-            defer { lock.signal() }
+            self.lock.lock()
+            defer { lock.unlock() }
             if let existing = self._storage[id] {
                 fatalError("Existing ActorID [\(id)] metadata, cannot be replaced. Was: [\(existing)], newValue: [\(optional: newValue)]")
             }
@@ -180,16 +183,16 @@ public final class ActorMetadata: CustomStringConvertible, CustomDebugStringConv
     }
 
     public var description: String {
-        self.lock.wait()
+        self.lock.lock()
         let copy = self._storage
-        self.lock.signal()
+        self.lock.unlock()
         return "\(copy)"
     }
 
     public var debugDescription: String {
-        self.lock.wait()
+        self.lock.lock()
         let copy = self._storage
-        self.lock.signal()
+        self.lock.unlock()
         return "\(Self.self)(\(copy))"
     }
 }

--- a/Sources/DistributedCluster/ActorRef+Ask.swift
+++ b/Sources/DistributedCluster/ActorRef+Ask.swift
@@ -209,8 +209,9 @@ extension AskResponse: _AsyncResult {
     var _unsafeAsyncValue: Value {
         get async throws {
             try await withCheckedThrowingContinuation { cc in
-                _onComplete {
-                    cc.resume(with: $0)
+                _onComplete { result in
+                    nonisolated(unsafe) let unsafeResult = result
+                    cc.resume(with: unsafeResult)
                 }
             }
         }
@@ -284,8 +285,9 @@ internal enum AskActor {
                 }
             }
 
+            let capturedTimeout = scheduledTimeout
             return .receiveMessage { message in
-                scheduledTimeout?.cancel()
+                capturedTimeout?.cancel()
                 completable.succeed(message)
 
                 return .stop

--- a/Sources/DistributedCluster/ActorRef+Ask.swift
+++ b/Sources/DistributedCluster/ActorRef+Ask.swift
@@ -256,9 +256,11 @@ internal enum AskActor {
         function: String,
         line: UInt
     ) -> _Behavior<ResponseType> {
+        nonisolated(unsafe) let completable = completable
         // TODO: could we optimize the case when the target is _local_ and _terminated_ so we don't have to do the watch dance (heavy if we did it always),
         // but make dead letters tell us back that our ask will never reply?
-        .setup { context in
+        return .setup { context in
+            nonisolated(unsafe) let context = context
             var scheduledTimeout: Scheduled<Void>?
             if !timeout.isEffectivelyInfinite {
                 let timeoutSub = context.subReceive(Event.self) { event in

--- a/Sources/DistributedCluster/ActorShell+Children.swift
+++ b/Sources/DistributedCluster/ActorShell+Children.swift
@@ -396,7 +396,7 @@ extension _ActorShell {
 }
 
 /// Errors which can occur while executing actions on the [ActorContext].
-public struct _ActorContextError: Error, CustomStringConvertible {
+public struct _ActorContextError: Error, CustomStringConvertible, @unchecked Sendable {
     internal enum __ActorContextError {
         /// It is illegal to `context.stop(context.myself)` as it would result in potentially unexpected behavior,
         /// as the actor would continue running until it receives the stop message. Rather, to stop the current actor

--- a/Sources/DistributedCluster/ActorShell+Children.swift
+++ b/Sources/DistributedCluster/ActorShell+Children.swift
@@ -26,7 +26,9 @@ internal enum Child {
 /// Convenience methods for locating children are provided, although it is recommended to keep the `_ActorRef`
 /// of spawned actors in the context of where they are used, rather than looking them up continuously.
 // TODO(swift): remove the concept of child actors and the actor tree
-public class _Children {
+// @unchecked Sendable: Legacy C mailbox runtime. This type is planned for removal
+// when _ActorShell is replaced with Swift's native actor runtime. See GitHub issue #5.
+public class _Children: @unchecked Sendable {
     // Implementation note: access is optimized for fetching by name, as that's what we do during child lookup
     // as well as actor tree traversal.
     private typealias Name = String

--- a/Sources/DistributedCluster/Behaviors.swift
+++ b/Sources/DistributedCluster/Behaviors.swift
@@ -464,7 +464,9 @@ extension _Behavior {
     }
 }
 
-internal enum __Behavior<Message: Codable> {
+// @unchecked Sendable: Contains non-@Sendable closures for message/signal handling.
+// Phase 3: behavior closures need @Sendable annotation before this can be checked Sendable.
+internal enum __Behavior<Message: Codable>: @unchecked Sendable {
     case setup(_ onStart: (_ActorContext<Message>) throws -> _Behavior<Message>)
 
     case receive(_ handle: (_ActorContext<Message>, Message) throws -> _Behavior<Message>)
@@ -496,7 +498,9 @@ internal enum __Behavior<Message: Codable> {
     indirect case suspended(previousBehavior: _Behavior<Message>, handler: (Result<Any, Error>) throws -> _Behavior<Message>)
 }
 
-internal enum StopReason {
+// @unchecked Sendable: Contains _Supervision.Failure which wraps Error (not Sendable).
+// Phase 3: constrain Error types to Sendable or use typed throws.
+internal enum StopReason: @unchecked Sendable {
     /// the actor decided to stop and returned _Behavior.stop
     case stopMyself
     /// a stop was requested by the parent, i.e. `context.stop(child:)`
@@ -505,7 +509,9 @@ internal enum StopReason {
     case failure(_Supervision.Failure)
 }
 
-enum IllegalBehaviorError<Message: Codable>: Error {
+// @unchecked Sendable: Contains _Behavior which is @unchecked Sendable.
+// Phase 3: will become checked Sendable once _Behavior is fully Sendable.
+enum IllegalBehaviorError<Message: Codable>: Error, @unchecked Sendable {
     /// Some behaviors, like `.same` and `.unhandled` are not allowed to be used as initial behaviors.
     /// See their individual documentation for the rationale why that is so.
     case notAllowedAsInitial(_ behavior: _Behavior<Message>)
@@ -539,7 +545,9 @@ extension _Behavior {
 }
 
 /// Used in combination with `_Behavior.intercept` to intercept messages and signals delivered to a behavior.
-open class _Interceptor<Message: Codable> {
+// @unchecked Sendable: Open class used for subclassing (e.g. supervision interceptors).
+// Phase 3: audit subclasses for thread safety before removing @unchecked.
+open class _Interceptor<Message: Codable>: @unchecked Sendable {
     public init() {}
 
     @inlinable

--- a/Sources/DistributedCluster/Behaviors.swift
+++ b/Sources/DistributedCluster/Behaviors.swift
@@ -35,14 +35,14 @@ extension _Behavior {
     /// Additionally exposes `ActorContext` which can be used to e.g. log messages, spawn child actors etc.
     ///
     /// - SeeAlso: `receiveMessage` convenience behavior for when you do not need to access the `ActorContext`.
-    public static func receive(_ handle: @escaping (_ActorContext<Message>, Message) throws -> _Behavior<Message>) -> _Behavior {
+    public static func receive(_ handle: @Sendable @escaping (_ActorContext<Message>, Message) throws -> _Behavior<Message>) -> _Behavior {
         _Behavior(underlying: .receive(handle))
     }
 
     /// Defines a behavior that will be executed with an incoming message by its hosting actor.
     ///
     /// - SeeAlso: `receive` convenience if you also need to access the `ActorContext`.
-    public static func receiveMessage(_ handle: @escaping (Message) throws -> _Behavior<Message>) -> _Behavior {
+    public static func receiveMessage(_ handle: @Sendable @escaping (Message) throws -> _Behavior<Message>) -> _Behavior {
         _Behavior(underlying: .receiveMessage(handle))
     }
 }
@@ -222,7 +222,7 @@ extension _Behavior {
     ///
     /// This can be used to obtain the context, logger or perform actions right when the actor starts
     /// (e.g. send an initial message, or subscribe to some event stream, configure receive timeouts, etc.).
-    public static func setup(_ onStart: @escaping (_ActorContext<Message>) throws -> _Behavior<Message>) -> _Behavior {
+    public static func setup(_ onStart: @Sendable @escaping (_ActorContext<Message>) throws -> _Behavior<Message>) -> _Behavior {
         _Behavior(underlying: .setup(onStart))
     }
 
@@ -240,7 +240,7 @@ extension _Behavior {
     /// and the actor itself will stop. Return this behavior to stop your actors. This is a convenience overload that
     /// allows users to specify a closure that will only be called on receipt of `_PostStop` and therefore does not
     /// need to get the signal passed in. It also does not need to return a new behavior, as the actor is already stopping.
-    public static func stop(_ postStop: @escaping (_ActorContext<Message>) throws -> Void) -> _Behavior<Message> {
+    public static func stop(_ postStop: @Sendable @escaping (_ActorContext<Message>) throws -> Void) -> _Behavior<Message> {
         _Behavior.stop(
             postStop: _Behavior.receiveSignal { context, signal in
                 if signal is _Signals._PostStop {
@@ -300,7 +300,7 @@ extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSpecificSignal` for convenience version of this behavior, simplifying handling a single type of `Signal`.
-    public func receiveSignal(_ handle: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public func receiveSignal(_ handle: @Sendable @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandling(
                 handleMessage: self,
@@ -310,7 +310,7 @@ extension _Behavior {
     }
 
     public func _receiveSignalAsync(
-        _ handle: @escaping @Sendable (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
+        _ handle: @Sendable @escaping (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
     ) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandlingAsync(
@@ -341,7 +341,7 @@ extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSpecificSignal` for convenience version of this behavior, simplifying handling a single type of `Signal`.
-    public static func receiveSignal(_ handle: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public static func receiveSignal(_ handle: @Sendable @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandling(
                 handleMessage: .unhandled,
@@ -365,7 +365,7 @@ extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSignal` which allows receiving multiple types of signals.
-    public func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @Sendable @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         // TODO: better type printout so we know we only handle SpecificSignal with this one
         self.receiveSignal { context, signal in
             switch signal {
@@ -392,7 +392,7 @@ extension _Behavior {
     ///
     /// - SeeAlso: `Signals` for a listing of signals that may be handled using this behavior.
     /// - SeeAlso: `receiveSignal` which allows receiving multiple types of signals.
-    public static func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    public static func receiveSpecificSignal<SpecificSignal: _Signal>(_: SpecificSignal.Type, _ handle: @Sendable @escaping (_ActorContext<Message>, SpecificSignal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .signalHandling(
                 handleMessage: .unhandled,
@@ -415,7 +415,7 @@ extension _Behavior {
 extension _Behavior {
     /// Allows handling signals such as termination or lifecycle events.
     @usableFromInline
-    internal static func signalHandling(handleMessage: _Behavior<Message>, handleSignal: @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    internal static func signalHandling(handleMessage: _Behavior<Message>, handleSignal: @Sendable @escaping (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .signalHandling(handleMessage: handleMessage, handleSignal: handleSignal))
     }
 
@@ -423,7 +423,7 @@ extension _Behavior {
     @usableFromInline
     internal static func signalHandlingAsync(
         handleMessage: _Behavior<Message>,
-        handleSignal: @escaping @Sendable (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
+        handleSignal: @Sendable @escaping (_ActorContext<Message>, _Signal) async throws -> _Behavior<Message>
     ) -> _Behavior<Message> {
         _Behavior(underlying: .signalHandlingAsync(handleMessage: handleMessage, handleSignal: handleSignal))
     }
@@ -432,7 +432,7 @@ extension _Behavior {
     ///
     /// MUST be canonicalized (to .suspended before storing in an `ActorCell`, as thr suspend behavior CAN NOT handle messages.
     @usableFromInline
-    internal static func suspend<T>(handler: @escaping (Result<T, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    internal static func suspend<T>(handler: @Sendable @escaping (Result<T, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(
             underlying: .suspend(handler: { result in
                 try handler(result.map { $0 as! T })  // cast here is okay, as user APIs are typed, so we should always get a T
@@ -446,7 +446,7 @@ extension _Behavior {
     /// This usually happens when an async operation that caused the suspension
     /// is completed.
     @usableFromInline
-    internal static func suspended(previousBehavior: _Behavior<Message>, handler: @escaping (Result<Any, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
+    internal static func suspended(previousBehavior: _Behavior<Message>, handler: @Sendable @escaping (Result<Any, Error>) throws -> _Behavior<Message>) -> _Behavior<Message> {
         _Behavior(underlying: .suspended(previousBehavior: previousBehavior, handler: handler))
     }
 
@@ -464,15 +464,15 @@ extension _Behavior {
     }
 }
 
-// @unchecked Sendable: Contains non-@Sendable closures for message/signal handling.
-// Phase 3: behavior closures need @Sendable annotation before this can be checked Sendable.
+// @unchecked Sendable: Closure cases now annotated @Sendable. Remaining @unchecked is due to
+// non-Sendable _ActorContext captured by callers (safe: single-threaded mailbox execution).
 internal enum __Behavior<Message: Codable>: @unchecked Sendable {
-    case setup(_ onStart: (_ActorContext<Message>) throws -> _Behavior<Message>)
+    case setup(_ onStart: @Sendable (_ActorContext<Message>) throws -> _Behavior<Message>)
 
-    case receive(_ handle: (_ActorContext<Message>, Message) throws -> _Behavior<Message>)
+    case receive(_ handle: @Sendable (_ActorContext<Message>, Message) throws -> _Behavior<Message>)
     case receiveAsync(_ handle: @Sendable (_ActorContext<Message>, Message) async throws -> _Behavior<Message>)
 
-    case receiveMessage(_ handle: (Message) throws -> _Behavior<Message>)
+    case receiveMessage(_ handle: @Sendable (Message) throws -> _Behavior<Message>)
     case receiveMessageAsync(_ handle: @Sendable (Message) async throws -> _Behavior<Message>)
 
     indirect case stop(postStop: _Behavior<Message>?, reason: StopReason)
@@ -480,7 +480,7 @@ internal enum __Behavior<Message: Codable>: @unchecked Sendable {
 
     indirect case signalHandling(
         handleMessage: _Behavior<Message>,
-        handleSignal: (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>
+        handleSignal: @Sendable (_ActorContext<Message>, _Signal) throws -> _Behavior<Message>
     )
     indirect case signalHandlingAsync(
         handleMessage: _Behavior<Message>,
@@ -494,8 +494,8 @@ internal enum __Behavior<Message: Codable>: @unchecked Sendable {
 
     indirect case orElse(first: _Behavior<Message>, second: _Behavior<Message>)
 
-    case suspend(handler: (Result<Any, Error>) throws -> _Behavior<Message>)
-    indirect case suspended(previousBehavior: _Behavior<Message>, handler: (Result<Any, Error>) throws -> _Behavior<Message>)
+    case suspend(handler: @Sendable (Result<Any, Error>) throws -> _Behavior<Message>)
+    indirect case suspended(previousBehavior: _Behavior<Message>, handler: @Sendable (Result<Any, Error>) throws -> _Behavior<Message>)
 }
 
 // @unchecked Sendable: Contains _Supervision.Failure which wraps Error (not Sendable).

--- a/Sources/DistributedCluster/Behaviors.swift
+++ b/Sources/DistributedCluster/Behaviors.swift
@@ -59,13 +59,19 @@ extension _Behavior {
         let loop = context.system._eventLoopGroup.next()
         let promise = loop.makePromise(of: _Behavior<Message>.self)
 
+        // nonisolated(unsafe): Message may not conform to Sendable, and EventLoopPromise is not Sendable,
+        // but both are consumed exactly once in the Task closure. Thread safety is guaranteed by the
+        // actor mailbox serialization.
+        nonisolated(unsafe) let message = message
+        nonisolated(unsafe) let unsafePromise = promise
+
         // TODO: pretty sub-optimal, but we'll flatten this all out eventually
         Task {
             do {
                 let next = try await recv(message)
-                promise.succeed(next)
+                unsafePromise.succeed(next)
             } catch {
-                promise.fail(error)
+                unsafePromise.fail(error)
             }
         }
 
@@ -81,7 +87,8 @@ extension _Behavior {
         _ message: Message
     ) -> _Behavior<Message> {
         .setup { context in
-            receiveAsync0(
+            nonisolated(unsafe) let context = context
+            return receiveAsync0(
                 { message in
                     try await recv(context, message)
                 },

--- a/Sources/DistributedCluster/Behaviors.swift
+++ b/Sources/DistributedCluster/Behaviors.swift
@@ -62,13 +62,13 @@ extension _Behavior {
         // nonisolated(unsafe): Message may not conform to Sendable, and EventLoopPromise is not Sendable,
         // but both are consumed exactly once in the Task closure. Thread safety is guaranteed by the
         // actor mailbox serialization.
-        nonisolated(unsafe) let message = message
+        nonisolated(unsafe) let unsafeMessage = message
         nonisolated(unsafe) let unsafePromise = promise
 
         // TODO: pretty sub-optimal, but we'll flatten this all out eventually
-        Task {
+        Task { @Sendable in
             do {
-                let next = try await recv(message)
+                let next = try await recv(unsafeMessage)
                 unsafePromise.succeed(next)
             } catch {
                 unsafePromise.fail(error)
@@ -86,11 +86,12 @@ extension _Behavior {
         _ recv: @Sendable @escaping (_ActorContext<Message>, Message) async throws -> _Behavior<Message>,
         _ message: Message
     ) -> _Behavior<Message> {
-        .setup { context in
+        nonisolated(unsafe) let message = message
+        return .setup { context in
             nonisolated(unsafe) let context = context
             return receiveAsync0(
-                { message in
-                    try await recv(context, message)
+                { msg in
+                    try await recv(context, msg)
                 },
                 context: context,
                 message: message
@@ -103,7 +104,8 @@ extension _Behavior {
         _ recv: @Sendable @escaping (Message) async throws -> _Behavior<Message>,
         _ message: Message
     ) -> _Behavior<Message> {
-        .setup { context in
+        nonisolated(unsafe) let message = message
+        return .setup { context in
             receiveAsync0(recv, context: context, message: message)
         }
     }
@@ -117,13 +119,16 @@ extension _Behavior {
             let loop = context.system._eventLoopGroup.next()
             let promise = loop.makePromise(of: _Behavior<Message>.self)
 
+            nonisolated(unsafe) let unsafeContext = context
+            nonisolated(unsafe) let unsafePromise = promise
+
             // TODO: pretty sub-optimal, but we'll flatten this all out eventually
             Task {
                 do {
-                    let next = try await handleSignal(context, signal)
-                    promise.succeed(next)
+                    let next = try await handleSignal(unsafeContext, signal)
+                    unsafePromise.succeed(next)
                 } catch {
-                    promise.fail(error)
+                    unsafePromise.fail(error)
                 }
             }
 

--- a/Sources/DistributedCluster/Clocks/Protobuf/VersionVector.pb.swift
+++ b/Sources/DistributedCluster/Clocks/Protobuf/VersionVector.pb.swift
@@ -232,7 +232,7 @@ extension _ProtoActorIdentity: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
         var _manifest: _ProtoManifest? = nil
         var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -301,7 +301,7 @@ extension _ProtoVersionReplicaID: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     fileprivate class _StorageClass {
         var _value: _ProtoVersionReplicaID.OneOf_Value?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -390,7 +390,7 @@ extension _ProtoReplicaVersion: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
         var _replicaID: _ProtoVersionReplicaID? = nil
         var _version: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -488,7 +488,7 @@ extension _ProtoVersionDot: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         var _replicaID: _ProtoVersionReplicaID? = nil
         var _version: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -559,7 +559,7 @@ extension _ProtoVersionDottedElementEnvelope: SwiftProtobuf.Message, SwiftProtob
         var _manifest: _ProtoManifest? = nil
         var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Cluster/Association.swift
+++ b/Sources/DistributedCluster/Cluster/Association.swift
@@ -34,6 +34,11 @@ import struct Foundation.Date
 ///
 /// A completed ("associated") `Association` can ONLY be obtained by successfully completing a `HandshakeStateMachine` dance,
 /// as only the handshake can ensure that the other side is also an actor node that is able and willing to communicate with us.
+/// @unchecked Sendable: Thread safety is provided by `lock` (Lock) which protects all mutable fields:
+/// - `state` (State): transitions through .associating -> .associated -> .tombstone
+/// - `completionTasks` ([() -> Void]): accumulated tasks executed on state transition
+/// - `remoteNode` (Cluster.Node): set during init, may be read under lock
+/// The remaining fields (`selfNode`, `lock`) are immutable after init.
 final class Association: CustomStringConvertible, @unchecked Sendable {
     // TODO: Terrible lock which we want to get rid of; it means that every remote send has to content against all other sends about getting this ref
     // and the only reason is really because the off chance case in which we have to make an Association earlier than we have the handshake completed (i.e. we send to a ref that is not yet associated)

--- a/Sources/DistributedCluster/Cluster/Cluster+Event.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Event.swift
@@ -19,7 +19,7 @@ extension Cluster {
     /// Represents cluster events, most notably regarding membership and reachability of other members of the cluster.
     ///
     /// Inspect them directly, or `apply` to a `Membership` copy in order to be able to react to membership state of the cluster.
-    public enum Event: Codable, Equatable {
+    public enum Event: Codable, Equatable, Sendable {
         case snapshot(Membership)
         case membershipChange(MembershipChange)
         case reachabilityChange(ReachabilityChange)
@@ -167,7 +167,7 @@ extension Cluster.MembershipChange: CustomStringConvertible {
 
 extension Cluster {
     /// Emitted when the reachability of a member changes, as determined by a failure detector (e.g. `SWIM`).
-    public struct ReachabilityChange: Equatable {
+    public struct ReachabilityChange: Equatable, Sendable {
         public let member: Cluster.Member
 
         public init(member: Member) {
@@ -195,7 +195,7 @@ extension Cluster {
 
 extension Cluster {
     /// Emitted when a change in leader is decided.
-    public struct LeadershipChange: Hashable {
+    public struct LeadershipChange: Hashable, Sendable {
         // let role: Role if this leader was of a specific role, carry the info here? same for DC?
         public let oldLeader: Cluster.Member?
         public let newLeader: Cluster.Member?

--- a/Sources/DistributedCluster/Cluster/Cluster+Event.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Event.swift
@@ -33,7 +33,7 @@ extension Cluster {
 extension Cluster {
     /// Represents a change made to a `Membership`, it can be received from gossip and shall be applied to local memberships,
     /// or may originate from local decisions (such as joining or downing).
-    public struct MembershipChange: Hashable {
+    public struct MembershipChange: Hashable, Sendable {
         /// Current member that is part of the membership after this change
         public internal(set) var member: Member
 

--- a/Sources/DistributedCluster/Cluster/Cluster+Member.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Member.swift
@@ -133,13 +133,13 @@ extension Cluster.Member {
     /// few core nodes which become "old" and tons of ad-hoc spun up nodes which are always "young" as they are spawned
     /// and stopped on demand. Putting certain types of workloads onto "old(est)" nodes in such clusters has the benefit
     /// of most likely not needing to balance/move work off them too often (in face of many ad-hoc worker spawns).
-    public static let ageOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
+    public nonisolated(unsafe) static let ageOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
         (l._upNumber ?? 0) < (r._upNumber ?? 0)
     }
 
     /// An ordering by the members' `node` properties, e.g. 1.1.1.1 is "lower" than 2.2.2.2.
     /// This ordering somewhat unusual, however always consistent and used to select a leader -- see `LowestReachableMember`.
-    public static let lowestAddressOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
+    public nonisolated(unsafe) static let lowestAddressOrdering: (Cluster.Member, Cluster.Member) -> Bool = { l, r in
         l.node < r.node
     }
 }
@@ -260,7 +260,7 @@ extension Cluster.MemberStatus: Codable {
 // MARK: Cluster.MemberStatus Ordering
 
 extension Cluster.MemberStatus {
-    public static let lifecycleOrdering: (Cluster.Member, Cluster.Member) -> Bool = { $0.status < $1.status }
+    public nonisolated(unsafe) static let lifecycleOrdering: (Cluster.Member, Cluster.Member) -> Bool = { $0.status < $1.status }
 }
 
 extension Cluster.MemberStatus {

--- a/Sources/DistributedCluster/Cluster/Cluster+Membership.swift
+++ b/Sources/DistributedCluster/Cluster/Cluster+Membership.swift
@@ -694,7 +694,7 @@ extension MembershipDiff: CustomDebugStringConvertible {
 // MARK: Errors
 
 extension Cluster {
-    public struct MembershipError: Error, CustomStringConvertible {
+    public struct MembershipError: Error, CustomStringConvertible, @unchecked Sendable {
         internal enum _MembershipError: CustomPrettyStringConvertible {
             case nonMemberLeaderSelected(Cluster.Membership, wannabeLeader: Cluster.Member)
             case notFound(Cluster.Node, in: Cluster.Membership)

--- a/Sources/DistributedCluster/Cluster/ClusterControl.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterControl.swift
@@ -49,8 +49,9 @@ public struct ClusterControl {
     }
 
     internal func updateMembershipSnapshot(_ snapshot: Cluster.Membership) {
+        let holder = self._membershipSnapshotHolder
         Task {
-            await self._membershipSnapshotHolder.update(snapshot)
+            await holder.update(snapshot)
         }
     }
 
@@ -230,11 +231,16 @@ public struct ClusterControl {
     ///   - status: The expected member status.
     ///   - within: Duration to wait for.
     public func waitFor(_ nodes: some Collection<Cluster.Node>, _ status: Cluster.MemberStatus, within: Duration) async throws {
+        nonisolated(unsafe) let selfUnsafe = self
+        nonisolated(unsafe) let status = status
+        nonisolated(unsafe) let within = within
         try await withThrowingTaskGroup(of: Void.self) { group in
             for node in nodes {
-                group.addTask {
-                    try await self.waitFor(node, status, within: within)
+                nonisolated(unsafe) let node = node
+                let task: @Sendable () async throws -> Void = {
+                    try await selfUnsafe.waitFor(node, status, within: within)
                 }
+                group.addTask(operation: task)
             }
             // loop explicitly to propagate any error that might have been thrown
             for try await _ in group {}
@@ -248,11 +254,16 @@ public struct ClusterControl {
     ///   - atLeastStatus: The minimum expected member status.
     ///   - within: Duration to wait for.
     public func waitFor(_ nodes: some Collection<Cluster.Node>, atLeast atLeastStatus: Cluster.MemberStatus, within: Duration) async throws {
+        nonisolated(unsafe) let selfUnsafe = self
+        nonisolated(unsafe) let atLeastStatus = atLeastStatus
+        nonisolated(unsafe) let within = within
         try await withThrowingTaskGroup(of: Void.self) { group in
             for node in nodes {
-                group.addTask {
-                    _ = try await self.waitFor(node, atLeast: atLeastStatus, within: within)
+                nonisolated(unsafe) let node = node
+                let task: @Sendable () async throws -> Void = {
+                    _ = try await selfUnsafe.waitFor(node, atLeast: atLeastStatus, within: within)
                 }
+                group.addTask(operation: task)
             }
             // loop explicitly to propagate any error that might have been thrown
             for try await _ in group {}

--- a/Sources/DistributedCluster/Cluster/ClusterEventStream.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterEventStream.swift
@@ -39,8 +39,9 @@ public struct ClusterEventStream: AsyncSequence {
 
     nonisolated func subscribe(_ ref: _ActorRef<Cluster.Event>, file: String = #filePath, line: UInt = #line) {
         nonisolated(unsafe) let ref = ref
+        nonisolated(unsafe) let selfUnsafe = self
         Task {
-            await self._subscribe(ref, file: file, line: line)
+            await selfUnsafe._subscribe(ref, file: file, line: line)
         }
     }
 
@@ -54,8 +55,9 @@ public struct ClusterEventStream: AsyncSequence {
 
     nonisolated func unsubscribe(_ ref: _ActorRef<Cluster.Event>, file: String = #filePath, line: UInt = #line) {
         nonisolated(unsafe) let ref = ref
+        nonisolated(unsafe) let selfUnsafe = self
         Task {
-            await self._unsubscribe(ref, file: file, line: line)
+            await selfUnsafe._unsubscribe(ref, file: file, line: line)
         }
     }
 
@@ -70,6 +72,7 @@ public struct ClusterEventStream: AsyncSequence {
     private func subscribe(_ oid: ObjectIdentifier, eventHandler: @escaping (Cluster.Event) -> Void) async {
         guard let actor = self.actor else { return }
 
+        nonisolated(unsafe) let eventHandler = eventHandler
         await actor.whenLocal { __secretlyKnownToBeLocal in  // TODO(distributed): this is annoying, we must track "known to be local" in typesystem instead
             __secretlyKnownToBeLocal.subscribe(oid, eventHandler: eventHandler)
         }
@@ -100,6 +103,7 @@ public struct ClusterEventStream: AsyncSequence {
 
         init(_ eventStream: ClusterEventStream) {
             let id = ObjectIdentifier(self)
+            nonisolated(unsafe) let eventStream = eventStream
             self.underlying = AsyncStream<Cluster.Event> { continuation in
                 Task {
                     await eventStream.subscribe(id) { event in

--- a/Sources/DistributedCluster/Cluster/ClusterEventStream.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterEventStream.swift
@@ -38,6 +38,7 @@ public struct ClusterEventStream: AsyncSequence {
     }
 
     nonisolated func subscribe(_ ref: _ActorRef<Cluster.Event>, file: String = #filePath, line: UInt = #line) {
+        nonisolated(unsafe) let ref = ref
         Task {
             await self._subscribe(ref, file: file, line: line)
         }
@@ -52,6 +53,7 @@ public struct ClusterEventStream: AsyncSequence {
     }
 
     nonisolated func unsubscribe(_ ref: _ActorRef<Cluster.Event>, file: String = #filePath, line: UInt = #line) {
+        nonisolated(unsafe) let ref = ref
         Task {
             await self._unsubscribe(ref, file: file, line: line)
         }

--- a/Sources/DistributedCluster/Cluster/ClusterShell+LeaderActions.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterShell+LeaderActions.swift
@@ -100,9 +100,10 @@ extension ClusterShell {
 
         system.cluster.updateMembershipSnapshot(state.membership)
 
-        Task { [eventsToPublish, state] in
+        nonisolated(unsafe) let events = state.events
+        Task {
             for event in eventsToPublish {
-                await state.events.publish(event)
+                await events.publish(event)
             }
         }
 

--- a/Sources/DistributedCluster/Cluster/ClusterShell.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterShell.swift
@@ -392,6 +392,7 @@ extension ClusterShell {
     /// Once bound proceeds to `ready` state, where it remains to accept or initiate new handshakes.
     private func bind() -> _Behavior<Message> {
         .setup { context in
+            nonisolated(unsafe) let context = context
             // let clusterSettings = context.system.settings
             let bindNode = self.selfNode
 
@@ -497,7 +498,8 @@ extension ClusterShell {
     ///
     /// Serves as main "driver" for handshake and association state machines.
     private func ready(state: ClusterShellState) -> _Behavior<Message> {
-        func receiveShellCommand(_ context: _ActorContext<Message>, command: CommandMessage) -> _Behavior<Message> {
+        nonisolated(unsafe) let state = state
+        @Sendable func receiveShellCommand(_ context: _ActorContext<Message>, command: CommandMessage) -> _Behavior<Message> {
             state.tracelog(.inbound, message: command)
 
             switch command {
@@ -538,7 +540,7 @@ extension ClusterShell {
             }
         }
 
-        func receiveQuery(_ context: _ActorContext<Message>, query: QueryMessage) -> _Behavior<Message> {
+        @Sendable func receiveQuery(_ context: _ActorContext<Message>, query: QueryMessage) -> _Behavior<Message> {
             state.tracelog(.inbound, message: query)
 
             switch query {
@@ -551,7 +553,7 @@ extension ClusterShell {
             }
         }
 
-        func receiveInbound(_ context: _ActorContext<Message>, message: InboundMessage) throws -> _Behavior<Message> {
+        @Sendable func receiveInbound(_ context: _ActorContext<Message>, message: InboundMessage) throws -> _Behavior<Message> {
             switch message {
             case .handshakeOffer(let offer, let channel, let promise):
                 self.tracelog(context, .receiveUnique(from: offer.originNode), message: offer)
@@ -576,7 +578,7 @@ extension ClusterShell {
         }
 
         /// Allows processing in one spot, all membership changes which we may have emitted in other places, due to joining, downing etc.
-        func receiveChangeMembershipRequest(_ context: _ActorContext<Message>, event: Cluster.Event) -> _Behavior<Message> {
+        @Sendable func receiveChangeMembershipRequest(_ context: _ActorContext<Message>, event: Cluster.Event) -> _Behavior<Message> {
             self.tracelog(context, .receive(from: state.selfNode.endpoint), message: event)
             var state = state
 
@@ -612,7 +614,7 @@ extension ClusterShell {
             return self.ready(state: state)
         }
 
-        func receiveMembershipGossip(
+        @Sendable func receiveMembershipGossip(
             _ context: _ActorContext<Message>,
             _ state: ClusterShellState,
             gossip: Cluster.MembershipGossip

--- a/Sources/DistributedCluster/Cluster/ClusterShell.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterShell.swift
@@ -477,6 +477,7 @@ extension ClusterShell {
     }
 
     private func publish(_ event: Cluster.Event, to eventStream: ClusterEventStream) {
+        nonisolated(unsafe) let eventStream = eventStream
         Task {
             await eventStream.publish(event)
         }  // TODO(send): we need "send"

--- a/Sources/DistributedCluster/Cluster/ClusterShell.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterShell.swift
@@ -30,7 +30,13 @@ public enum Cluster {}
 /// as well as orchestrating any high-level membership changes, e.g. by interacting with a failure detector and other gossip mechanisms.
 ///
 /// It keeps the `Membership` instance that can be seen the source of truth for any membership based decisions.
-internal class ClusterShell {
+// @unchecked Sendable justification:
+// ClusterShell is a class shared across actor/task boundaries. Thread safety is provided by:
+// - `_associationsLock` guards `_associations` and `_associationTombstones`
+// - `refLock` guards `_ref`
+// - `_serializationPool`, `_swimShell`, and `clusterEvents` are set once during `start()` and read-only thereafter
+// - All message processing is serialized through the actor mailbox (_ActorShell)
+internal class ClusterShell: @unchecked Sendable {
     internal static let naming = _ActorNaming.unique("cluster")
     public typealias Ref = _ActorRef<ClusterShell.Message>
 
@@ -47,6 +53,11 @@ internal class ClusterShell {
     // which would cause more latency to obtaining the association. refs cache the remote control once they have obtained it.
 
     // TODO: consider ReadWriteLock lock, these accesses are very strongly read only biased
+    // Guards: [_associations, _associationTombstones]
+    // Acquired by: getAnyExistingAssociation, getExistingAssociationTombstone, getEnsureAssociation,
+    //   getSpecificExistingAssociation, completeAssociation, terminateAssociation,
+    //   _testingOnly_associations, _testingOnly_associationTombstones, _associatedNodes,
+    //   cleanUpAssociationTombstones, recordMetrics
     private let _associationsLock: Lock
 
     /// Used by remote actor refs to obtain associations
@@ -237,6 +248,7 @@ internal class ClusterShell {
 
     // `_serializationPool` is only used when `start()` is invoked, and there it is set immediately as well
     // any earlier access to the pool is a bug (in our library) and must be treated as such.
+    // FIXME: Swift 6 — verify concurrent access safety (set once in start(), read-only thereafter)
     private var _serializationPool: _SerializationPool?
     internal var serializationPool: _SerializationPool {
         guard let pool = self._serializationPool else {
@@ -245,13 +257,17 @@ internal class ClusterShell {
         return pool
     }
 
+    // FIXME: Swift 6 — verify concurrent access safety (set once in start(), read-only thereafter)
     internal private(set) var _swimShell: SWIMActor!
 
+    // FIXME: Swift 6 — verify concurrent access safety (set once in start(), read-only thereafter)
     private var clusterEvents: ClusterEventStream!
 
     // ==== ------------------------------------------------------------------------------------------------------------
     // MARK: Cluster Shell, reference used for issuing commands to the cluster
 
+    // Guards: [_ref]
+    // Acquired by: ref (getter)
     private let refLock = Lock()
 
     private var _ref: ClusterShell.Ref?

--- a/Sources/DistributedCluster/Cluster/ClusterShellState.swift
+++ b/Sources/DistributedCluster/Cluster/ClusterShellState.swift
@@ -35,6 +35,8 @@ internal protocol ReadOnlyClusterState {
 }
 
 /// State of the `ClusterShell` state machine.
+/// Not Sendable: this struct is only accessed within the ClusterShell's serialized actor mailbox.
+/// Contains non-Sendable types (Channel, EventLoopGroup, GossiperControl).
 internal struct ClusterShellState: ReadOnlyClusterState {
     typealias Messages = ClusterShell.Message
 
@@ -481,7 +483,7 @@ extension ClusterShellState {
         return .init(applied: changeWasApplied)
     }
 
-    struct AppliedClusterEventDirective {
+    struct AppliedClusterEventDirective: Sendable {
         // True if the change was applied, modifying the Membership.
         let applied: Bool
     }

--- a/Sources/DistributedCluster/Cluster/DiscoveryShell.swift
+++ b/Sources/DistributedCluster/Cluster/DiscoveryShell.swift
@@ -15,7 +15,8 @@
 import Logging
 import ServiceDiscovery
 
-final class DiscoveryShell {
+// @unchecked Sendable: Mutable state is only accessed from within the actor's mailbox run (single-threaded).
+final class DiscoveryShell: @unchecked Sendable {
     enum Message: _NotActuallyCodableMessage {
         case listing(Set<Cluster.Endpoint>)
         case stop(CompletionReason?)
@@ -34,6 +35,7 @@ final class DiscoveryShell {
 
     var behavior: _Behavior<Message> {
         .setup { context in
+            nonisolated(unsafe) let context = context
             // FIXME: should have a behavior to bridge the async world...
             context.log.info("Initializing discovery: \(self.settings.implementation)")
             // Try to initialise clusterd if needed

--- a/Sources/DistributedCluster/Cluster/Downing/DowningSettings.swift
+++ b/Sources/DistributedCluster/Cluster/Downing/DowningSettings.swift
@@ -67,6 +67,7 @@ public struct OnDownActionStrategySettings {
 
         case .gracefulShutdown(let shutdownDelay):
             return { system in
+                nonisolated(unsafe) let system = system
                 try system._spawn(
                     "leaver",
                     of: String.self,

--- a/Sources/DistributedCluster/Cluster/Downing/DowningSettings.swift
+++ b/Sources/DistributedCluster/Cluster/Downing/DowningSettings.swift
@@ -17,8 +17,8 @@ import Logging
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: DowningStrategySettings
 
-public struct DowningStrategySettings {
-    private enum _DowningStrategySettings {
+public struct DowningStrategySettings: Sendable {
+    private enum _DowningStrategySettings: Sendable {
         case none
         case timeout(TimeoutBasedDowningStrategySettings)
     }
@@ -48,8 +48,8 @@ public struct DowningStrategySettings {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: OnDownActionStrategySettings
 
-public struct OnDownActionStrategySettings {
-    private enum _OnDownActionStrategySettings {
+public struct OnDownActionStrategySettings: @unchecked Sendable {
+    private enum _OnDownActionStrategySettings: @unchecked Sendable {
         case none
         case gracefulShutdown(delay: Duration)
     }

--- a/Sources/DistributedCluster/Cluster/Downing/TimeoutBasedDowningStrategy.swift
+++ b/Sources/DistributedCluster/Cluster/Downing/TimeoutBasedDowningStrategy.swift
@@ -135,7 +135,7 @@ public final class TimeoutBasedDowningStrategy: DowningStrategy {
     }
 }
 
-public struct TimeoutBasedDowningStrategySettings {
+public struct TimeoutBasedDowningStrategySettings: Sendable {
     /// Provides a slight delay after noticing an `.unreachable` before declaring down.
     ///
     /// Generally with a distributed failure detector such delay may not be necessary, however it is available in case

--- a/Sources/DistributedCluster/Cluster/Leadership.swift
+++ b/Sources/DistributedCluster/Cluster/Leadership.swift
@@ -324,8 +324,8 @@ extension Leadership {
 
 extension ClusterSystemSettings {
     /// Configure leadership election using which the cluster leader should be decided.
-    public struct LeadershipSelectionSettings {
-        private enum _LeadershipSelectionSettings {
+    public struct LeadershipSelectionSettings: Sendable {
+        private enum _LeadershipSelectionSettings: Sendable {
             case none
             case lowestReachable(minNumberOfMembers: Int)
         }

--- a/Sources/DistributedCluster/Cluster/Leadership.swift
+++ b/Sources/DistributedCluster/Cluster/Leadership.swift
@@ -98,7 +98,8 @@ public struct LeaderElectionResult: _AsyncResult {
 public struct Leadership {}
 
 extension Leadership {
-    final class Shell {
+    // @unchecked Sendable: Mutable state is only accessed from within the actor's mailbox run (single-threaded).
+    final class Shell: @unchecked Sendable {
         static let naming: _ActorNaming = "leadership"
 
         private var membership: Cluster.Membership  // FIXME: we need to ensure the membership is always up to date -- we need the initial snapshot or a diff from a zero state etc.
@@ -111,6 +112,7 @@ extension Leadership {
 
         var behavior: _Behavior<Cluster.Event> {
             .setup { context in
+                nonisolated(unsafe) let context = context
                 context.log.trace("Configured with \(self.election)")
                 context.system.cluster.events.subscribe(context.myself)
 
@@ -122,6 +124,7 @@ extension Leadership {
 
         private var ready: _Behavior<Cluster.Event> {
             .receive { context, event in
+                nonisolated(unsafe) let context = context
                 switch event {
                 case .snapshot(let membership):
                     self.membership = membership
@@ -150,6 +153,7 @@ extension Leadership {
         }
 
         func runElection(_ context: _ActorContext<Cluster.Event>) -> _Behavior<Cluster.Event> {
+            nonisolated(unsafe) let context = context
             var electionContext = LeaderElectionContext(context)
             electionContext.log[metadataKey: "leadership/election"] = "\(String(reflecting: type(of: self.election)))"
             let electionResult = self.election.runElection(context: electionContext, membership: self.membership)

--- a/Sources/DistributedCluster/Cluster/MembershipGossip/Cluster+MembershipGossip.swift
+++ b/Sources/DistributedCluster/Cluster/MembershipGossip/Cluster+MembershipGossip.swift
@@ -19,7 +19,7 @@ extension Cluster {
     /// Gossip payload about members in the cluster.
     ///
     /// Used to guarantee phrases like "all nodes have seen a node A in status S", upon which the Leader may act.
-    struct MembershipGossip: Codable, Equatable {
+    struct MembershipGossip: Codable, Equatable, Sendable {
         let owner: Cluster.Node
         /// A table maintaining our perception of other nodes views on the version of membership.
         /// Each row in the table represents what versionVector we know the given node has observed recently.
@@ -118,7 +118,7 @@ extension Cluster {
             return change
         }
 
-        struct MergeDirective {
+        struct MergeDirective: Sendable {
             let causalRelation: VersionVector.CausalRelation
             let effectiveChanges: [Cluster.MembershipChange]
         }
@@ -180,7 +180,7 @@ extension Cluster.MembershipGossip {
     /// - node B: is the "farthest" along the vector timeline, yet has never seen gossip from C
     /// - node C (we think): has never seen any gossip from either A or B, realistically though it likely has,
     ///   however it has not yet sent a gossip to "us" such that we could have gotten its updated version vector.
-    struct SeenTable: Equatable {
+    struct SeenTable: Equatable, Sendable {
         var underlying: [Cluster.Node: VersionVector]
 
         init() {

--- a/Sources/DistributedCluster/Cluster/MembershipGossip/Cluster+MembershipGossipLogic.swift
+++ b/Sources/DistributedCluster/Cluster/MembershipGossip/Cluster+MembershipGossipLogic.swift
@@ -21,7 +21,9 @@ import NIO
 ///
 /// Membership gossip is what is used to reach cluster "convergence" upon which a leader may perform leader actions.
 /// See `Cluster.MembershipGossip.converged` for more details.
-final class MembershipGossipLogic: GossipLogic, CustomStringConvertible {
+// @unchecked Sendable: Mutable state is only accessed from within the owning GossipShell actor's mailbox.
+// Phase 3: verify single-threaded access pattern before removing @unchecked.
+final class MembershipGossipLogic: GossipLogic, CustomStringConvertible, @unchecked Sendable {
     typealias Gossip = Cluster.MembershipGossip
     typealias Acknowledgement = Cluster.MembershipGossip
 
@@ -137,7 +139,7 @@ final class MembershipGossipLogic: GossipLogic, CustomStringConvertible {
         }
     }
 
-    struct PeersChanged {
+    struct PeersChanged: Sendable {
         let added: Set<_AddressableActorRef>
         let removed: Set<_AddressableActorRef>
 

--- a/Sources/DistributedCluster/Cluster/NodeDeathWatcher.swift
+++ b/Sources/DistributedCluster/Cluster/NodeDeathWatcher.swift
@@ -31,7 +31,8 @@ import NIO
 /// Actor which is notified automatically when a remote actor is `context.watch()`-ed.
 ///
 /// Allows manually mocking membership changes to trigger terminated notifications.
-internal final class NodeDeathWatcherInstance: NodeDeathWatcher {
+// @unchecked Sendable: Mutable state is only accessed from within the enclosing actor's mailbox run (single-threaded).
+internal final class NodeDeathWatcherInstance: NodeDeathWatcher, @unchecked Sendable {
     private let selfNode: Cluster.Node
     private var membership: Cluster.Membership
 
@@ -191,6 +192,7 @@ enum NodeDeathWatcherShell {
     // FIXME: death watcher is incomplete, should handle snapshot!!
     static func behavior(clusterEvents: ClusterEventStream) -> _Behavior<Message> {
         .setup { context in
+            nonisolated(unsafe) let context = context
             let instance = NodeDeathWatcherInstance(selfNode: context.system.settings.bindNode)
 
             let onClusterEventRef = context.subReceive(Cluster.Event.self) { event in

--- a/Sources/DistributedCluster/Cluster/Protobuf/Cluster.pb.swift
+++ b/Sources/DistributedCluster/Cluster/Protobuf/Cluster.pb.swift
@@ -164,7 +164,7 @@ extension _ProtoClusterShellMessage: SwiftProtobuf.Message, SwiftProtobuf._Messa
     fileprivate class _StorageClass {
         var _message: _ProtoClusterShellMessage.OneOf_Message?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -244,7 +244,7 @@ extension _ProtoClusterInbound: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
     fileprivate class _StorageClass {
         var _message: _ProtoClusterInbound.OneOf_Message?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -314,7 +314,7 @@ extension _ProtoClusterRestInPeace: SwiftProtobuf.Message, SwiftProtobuf._Messag
         var _targetNode: _ProtoClusterNode? = nil
         var _fromNode: _ProtoClusterNode? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Cluster/Protobuf/ClusterEvents.pb.swift
+++ b/Sources/DistributedCluster/Cluster/Protobuf/ClusterEvents.pb.swift
@@ -169,7 +169,7 @@ extension _ProtoClusterEvent: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
     fileprivate class _StorageClass {
         var _event: _ProtoClusterEvent.OneOf_Event?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -263,7 +263,7 @@ extension _ProtoClusterMembershipChange: SwiftProtobuf.Message, SwiftProtobuf._M
         var _fromStatus: _ProtoClusterMemberStatus = .unspecified
         var _toStatus: _ProtoClusterMemberStatus = .unspecified
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -338,7 +338,7 @@ extension _ProtoClusterLeadershipChange: SwiftProtobuf.Message, SwiftProtobuf._M
         var _oldLeader: _ProtoClusterMember? = nil
         var _newLeader: _ProtoClusterMember? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Cluster/Protobuf/Membership.pb.swift
+++ b/Sources/DistributedCluster/Cluster/Protobuf/Membership.pb.swift
@@ -68,7 +68,7 @@ public enum _ProtoClusterMemberReachability: SwiftProtobuf.Enum {
 
 extension _ProtoClusterMemberReachability: CaseIterable {
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    public static var allCases: [_ProtoClusterMemberReachability] = [
+    public static let allCases: [_ProtoClusterMemberReachability] = [
         .unspecified,
         .reachable,
         .unreachable,
@@ -121,7 +121,7 @@ public enum _ProtoClusterMemberStatus: SwiftProtobuf.Enum {
 
 extension _ProtoClusterMemberStatus: CaseIterable {
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    public static var allCases: [_ProtoClusterMemberStatus] = [
+    public static let allCases: [_ProtoClusterMemberStatus] = [
         .unspecified,
         .joining,
         .up,
@@ -304,7 +304,7 @@ extension _ProtoClusterMembership: SwiftProtobuf.Message, SwiftProtobuf._Message
         var _members: [_ProtoClusterMember] = []
         var _leaderNode: _ProtoClusterNode? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -377,7 +377,7 @@ extension _ProtoClusterMember: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
         var _reachability: _ProtoClusterMemberReachability = .unspecified
         var _upNumber: UInt32 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -460,7 +460,7 @@ extension _ProtoClusterMembershipGossip: SwiftProtobuf.Message, SwiftProtobuf._M
         var _ownerClusterNodeID: UInt64 = 0
         var _seenTable: _ProtoClusterMembershipSeenTable? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -564,7 +564,7 @@ extension _ProtoClusterMembershipSeenTableRow: SwiftProtobuf.Message, SwiftProto
         var _nodeID: UInt64 = 0
         var _version: _ProtoVersionVector? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/OperationLogDistributedReceptionist.swift
@@ -1059,7 +1059,7 @@ extension OpLogDistributedReceptionist {
 extension OpLogDistributedReceptionist {
     /// Confirms that the remote peer receptionist has received Ops up until the given element,
     /// allows us to push more elements
-    final class PushOps: Receptionist.Message {
+    final class PushOps: Receptionist.Message, @unchecked Sendable {
         // the "sender" of the push
         let peer: OpLogDistributedReceptionist
 
@@ -1117,7 +1117,7 @@ extension OpLogDistributedReceptionist {
 
     /// Confirms that the remote peer receptionist has received Ops up until the given element,
     /// allows us to push more elements
-    final class AckOps: Receptionist.Message, CustomStringConvertible {
+    final class AckOps: Receptionist.Message, CustomStringConvertible, @unchecked Sendable {
         /// Cumulative ACK of all ops until (and including) this one.
         ///
         /// If a recipient has more ops than the `confirmedUntil` confirms seeing, it shall offer
@@ -1168,7 +1168,7 @@ extension OpLogDistributedReceptionist {
         }
     }
 
-    final class PublishLocalListingsTrigger: Receptionist.Message, _NotActuallyCodableMessage, CustomStringConvertible {
+    final class PublishLocalListingsTrigger: Receptionist.Message, _NotActuallyCodableMessage, CustomStringConvertible, @unchecked Sendable {
         override init() {
             super.init()
         }

--- a/Sources/DistributedCluster/Cluster/Reception/_OperationLogClusterReceptionistBehavior.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/_OperationLogClusterReceptionistBehavior.swift
@@ -673,7 +673,7 @@ extension _OperationLogClusterReceptionist {
 extension _OperationLogClusterReceptionist {
     /// Confirms that the remote peer receptionist has received Ops up until the given element,
     /// allows us to push more elements
-    class PushOps: Receptionist.Message {
+    class PushOps: Receptionist.Message, @unchecked Sendable {
         // the "sender" of the push
         let peer: _ActorRef<Receptionist.Message>
 
@@ -724,7 +724,7 @@ extension _OperationLogClusterReceptionist {
 
     /// Confirms that the remote peer receptionist has received Ops up until the given element,
     /// allows us to push more elements
-    class AckOps: Receptionist.Message, CustomStringConvertible {
+    class AckOps: Receptionist.Message, CustomStringConvertible, @unchecked Sendable {
         /// Cumulative ACK of all ops until (and including) this one.
         ///
         /// If a recipient has more ops than the `confirmedUntil` confirms seeing, it shall offer
@@ -775,7 +775,7 @@ extension _OperationLogClusterReceptionist {
         }
     }
 
-    class PeriodicAckTick: Receptionist.Message, _NotActuallyCodableMessage, CustomStringConvertible {
+    class PeriodicAckTick: Receptionist.Message, _NotActuallyCodableMessage, CustomStringConvertible, @unchecked Sendable {
         override init() {
             super.init()
         }
@@ -789,7 +789,7 @@ extension _OperationLogClusterReceptionist {
         }
     }
 
-    class PublishLocalListingsTrigger: Receptionist.Message, _NotActuallyCodableMessage, CustomStringConvertible {
+    class PublishLocalListingsTrigger: Receptionist.Message, _NotActuallyCodableMessage, CustomStringConvertible, @unchecked Sendable {
         override init() {
             super.init()
         }

--- a/Sources/DistributedCluster/Cluster/Reception/_OperationLogClusterReceptionistBehavior.swift
+++ b/Sources/DistributedCluster/Cluster/Reception/_OperationLogClusterReceptionistBehavior.swift
@@ -18,7 +18,8 @@ import Logging
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster (OpLog) Receptionist
 
-public final class _OperationLogClusterReceptionist {
+// @unchecked Sendable: Mutable state is only accessed from within the actor's mailbox run (single-threaded).
+public final class _OperationLogClusterReceptionist: @unchecked Sendable {
     typealias Message = Receptionist.Message
     typealias ReceptionistRef = _ActorRef<Message>
 
@@ -93,6 +94,7 @@ public final class _OperationLogClusterReceptionist {
 
     var behavior: _Behavior<Message> {
         .setup { context in
+            nonisolated(unsafe) let context = context
             context.log.debug("Initialized receptionist")
 
             // === listen to cluster events ------------------

--- a/Sources/DistributedCluster/Cluster/SWIM/Protobuf/SWIM.pb.swift
+++ b/Sources/DistributedCluster/Cluster/SWIM/Protobuf/SWIM.pb.swift
@@ -204,7 +204,7 @@ public struct _ProtoSWIMStatus {
 
 extension _ProtoSWIMStatus.TypeEnum: CaseIterable {
     // The compiler won't synthesize support with the UNRECOGNIZED case.
-    public static var allCases: [_ProtoSWIMStatus.TypeEnum] = [
+    public static let allCases: [_ProtoSWIMStatus.TypeEnum] = [
         .unspecified,
         .alive,
         .suspect,
@@ -274,7 +274,7 @@ extension _ProtoSWIMPingResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     fileprivate class _StorageClass {
         var _pingResponse: _ProtoSWIMPingResponse.OneOf_PingResponse?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -360,7 +360,7 @@ extension _ProtoSWIMPingResponse.Ack: SwiftProtobuf.Message, SwiftProtobuf._Mess
         var _payload: _ProtoSWIMGossipPayload? = nil
         var _sequenceNumber: UInt32 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -441,7 +441,7 @@ extension _ProtoSWIMPingResponse.Nack: SwiftProtobuf.Message, SwiftProtobuf._Mes
         var _target: _ProtoActorID? = nil
         var _sequenceNumber: UInt32 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -563,7 +563,7 @@ extension _ProtoSWIMMember: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
         var _status: _ProtoSWIMStatus? = nil
         var _protocolPeriod: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Cluster/SWIM/SWIMActor.swift
+++ b/Sources/DistributedCluster/Cluster/SWIM/SWIMActor.swift
@@ -44,11 +44,16 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
         )
     }
 
-    private lazy var log: Logger = {
-        var log = Logger(actor: self)
-        log.logLevel = self.settings.logger.logLevel
-        return log
-    }()
+    private var _log: Logger?
+    private var log: Logger {
+        get {
+            if let existing = _log { return existing }
+            var newLog = Logger(actor: self)
+            newLog.logLevel = self.settings.logger.logLevel
+            _log = newLog
+            return newLog
+        }
+    }
 
     var metrics: SWIM.Metrics {
         self.swim.metrics
@@ -191,27 +196,31 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
         nonisolated(unsafe) let log = self.log
         nonisolated(unsafe) let metrics = self.metrics
         nonisolated(unsafe) let swim = self.swim!
+        nonisolated(unsafe) let directive = directive
+        nonisolated(unsafe) let peerToPingUnsafe = peerToPing
+        nonisolated(unsafe) let pingTimeoutUnsafe = pingTimeout
         let firstSuccessful = await withTaskGroup(
             of: SWIM.PingResponse<SWIMActor, SWIMActor>.self,
             returning: SWIM.PingResponse<SWIMActor, SWIMActor>?.self
         ) { group in
             for pingRequest in directive.requestDetails {
+                nonisolated(unsafe) let pingRequest = pingRequest
                 group.addTask {
                     let peerToPingRequestThrough = pingRequest.peerToPingRequestThrough
                     let payload = pingRequest.payload
                     let sequenceNumber = pingRequest.sequenceNumber
 
-                    log.trace("Sending ping request for [\(peerToPing)] to [\(peerToPingRequestThrough)] with payload: \(payload)")
+                    log.trace("Sending ping request for [\(peerToPingUnsafe)] to [\(peerToPingRequestThrough)] with payload: \(payload)")
 
                     let pingRequestSentAt: DispatchTime = .now()
                     metrics.shell.messageOutboundCount.increment()
 
                     do {
                         let response = try await peerToPingRequestThrough.pingRequest(
-                            target: peerToPing,
+                            target: peerToPingUnsafe,
                             payload: payload,
                             from: self,
-                            timeout: pingTimeout,
+                            timeout: pingTimeoutUnsafe,
                             sequenceNumber: sequenceNumber
                         )
                         metrics.shell.pingRequestResponseTimeAll.recordInterval(since: pingRequestSentAt)
@@ -220,7 +229,7 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
                         log.debug(
                             ".pingRequest resulted in error",
                             metadata: swim.metadata([
-                                "swim/pingRequest/target": "\(peerToPing)",
+                                "swim/pingRequest/target": "\(peerToPingUnsafe)",
                                 "swim/pingRequest/peerToPingRequestThrough": "\(peerToPingRequestThrough)",
                                 "swim/pingRequest/sequenceNumber": "\(sequenceNumber)",
                                 "error": "\(error)",
@@ -231,17 +240,17 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
                         log.trace(
                             "Failed pingRequest",
                             metadata: [
-                                "swim/target": "\(peerToPing)",
+                                "swim/target": "\(peerToPingUnsafe)",
                                 "swim/payload": "\(payload)",
-                                "swim/pingTimeout": "\(pingTimeout)",
+                                "swim/pingTimeout": "\(pingTimeoutUnsafe)",
                                 "error": "\(error)",
                             ]
                         )
 
                         let response = SWIM.PingResponse<SWIMActor, SWIMActor>.timeout(
-                            target: peerToPing,
+                            target: peerToPingUnsafe,
                             pingRequestOrigin: self,
-                            timeout: pingTimeout,
+                            timeout: pingTimeoutUnsafe,
                             sequenceNumber: sequenceNumber
                         )
                         return response

--- a/Sources/DistributedCluster/Cluster/SWIM/SWIMActor.swift
+++ b/Sources/DistributedCluster/Cluster/SWIM/SWIMActor.swift
@@ -185,10 +185,16 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
         let startedSendingPingRequestsSentAt: DispatchTime = .now()
         let pingRequestResponseTimeFirstTimer = self.swim.metrics.shell.pingRequestResponseTimeFirst
 
+        // nonisolated(unsafe): log, metrics, swim are captured from actor-isolated context into @Sendable
+        // TaskGroup closures. Thread safety is guaranteed by the distributed actor's isolation — these
+        // captures are only used for logging/metrics within the task group and the actor serializes access.
+        nonisolated(unsafe) let log = self.log
+        nonisolated(unsafe) let metrics = self.metrics
+        nonisolated(unsafe) let swim = self.swim!
         let firstSuccessful = await withTaskGroup(
             of: SWIM.PingResponse<SWIMActor, SWIMActor>.self,
             returning: SWIM.PingResponse<SWIMActor, SWIMActor>?.self
-        ) { [log, metrics, swim] group in
+        ) { group in
             for pingRequest in directive.requestDetails {
                 group.addTask {
                     let peerToPingRequestThrough = pingRequest.peerToPingRequestThrough
@@ -213,7 +219,7 @@ internal distributed actor SWIMActor: SWIMPeer, SWIMAddressablePeer, CustomStrin
                     } catch {
                         log.debug(
                             ".pingRequest resulted in error",
-                            metadata: swim!.metadata([  // !-safe, initialized in init()
+                            metadata: swim.metadata([
                                 "swim/pingRequest/target": "\(peerToPing)",
                                 "swim/pingRequest/peerToPingRequestThrough": "\(peerToPingRequestThrough)",
                                 "swim/pingRequest/sequenceNumber": "\(sequenceNumber)",

--- a/Sources/DistributedCluster/Cluster/SystemMessages+Redelivery.swift
+++ b/Sources/DistributedCluster/Cluster/SystemMessages+Redelivery.swift
@@ -351,7 +351,7 @@ extension InboundSystemMessages.InboundSystemMessageArrivalDirective {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Settings
 
-public struct OutboundSystemMessageRedeliverySettings {
+public struct OutboundSystemMessageRedeliverySettings: Sendable {
     public static let `default`: OutboundSystemMessageRedeliverySettings = .init()
 
     /// When enabled, logs all outbound messages using the tracelog facility.
@@ -382,7 +382,7 @@ public struct OutboundSystemMessageRedeliverySettings {
     // var maxRedeliveryTicksWithoutACK = 10_000 // TODO settings
 }
 
-public struct InboundSystemMessageRedeliverySettings {
+public struct InboundSystemMessageRedeliverySettings: Sendable {
     public static let `default` = InboundSystemMessageRedeliverySettings()
 
     /// When enabled, logs all outbound messages using the tracelog facility.

--- a/Sources/DistributedCluster/Cluster/SystemMessages+Redelivery.swift
+++ b/Sources/DistributedCluster/Cluster/SystemMessages+Redelivery.swift
@@ -115,7 +115,8 @@ extension _SystemMessage {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Outbound Re-Delivery
 
-internal final class OutboundSystemMessageRedelivery {
+// @unchecked Sendable: Only accessed from within the NIO channel pipeline (single-threaded).
+internal final class OutboundSystemMessageRedelivery: @unchecked Sendable {
     typealias ACK = _SystemMessage.ACK
     typealias NACK = _SystemMessage.NACK
     typealias SequenceNr = SystemMessageEnvelope.SequenceNr
@@ -284,7 +285,8 @@ struct GiveUpRedeliveringSystemMessagesError: Error {}
 
 /// Each association has one inbound system message queue.
 @usableFromInline
-internal class InboundSystemMessages {
+// @unchecked Sendable: Only accessed from within the NIO channel pipeline (single-threaded).
+internal class InboundSystemMessages: @unchecked Sendable {
     typealias ACK = _SystemMessage.ACK
     typealias NACK = _SystemMessage.NACK
     typealias SequenceNr = SystemMessageEnvelope.SequenceNr

--- a/Sources/DistributedCluster/Cluster/Transport/RemoteClusterActorPersonality.swift
+++ b/Sources/DistributedCluster/Cluster/Transport/RemoteClusterActorPersonality.swift
@@ -23,7 +23,10 @@ import Atomics
 /// by being sent from a remote note, one can safely assume that the actor _existed_, however nothing
 /// is clear about its current lifecycle state (it may have already terminated the moment the message was sent,
 /// or even before then). To obtain lifecycle status of this actor the usual strategy of watching it needs to be employed.
-public final class _RemoteClusterActorPersonality<Message: Codable> {
+/// @unchecked Sendable: Thread safety is provided by `_cachedAssociation` (ManagedAtomicLazyReference)
+/// for the lazily-loaded association, and `Association` itself is lock-protected. The remaining fields
+/// (`id`, `clusterShell`, `system`) are effectively immutable after init.
+public final class _RemoteClusterActorPersonality<Message: Codable>: @unchecked Sendable {
     let id: ActorID
 
     let clusterShell: ClusterShell

--- a/Sources/DistributedCluster/Cluster/Transport/TransportPipelines.swift
+++ b/Sources/DistributedCluster/Cluster/Transport/TransportPipelines.swift
@@ -469,6 +469,7 @@ internal final class SystemMessageRedeliveryHandler: ChannelDuplexHandler, @unch
     }
 
     private func deserializeThenHandle<T>(type: T.Type, wireEnvelope: Wire.Envelope, callback: @escaping (T) -> Void) {
+        nonisolated(unsafe) let callback = callback
         self.serializationPool.deserializeAny(
             from: wireEnvelope.payload,
             using: wireEnvelope.manifest,

--- a/Sources/DistributedCluster/Cluster/Transport/TransportPipelines.swift
+++ b/Sources/DistributedCluster/Cluster/Transport/TransportPipelines.swift
@@ -26,11 +26,12 @@ import class NIOExtras.LengthFieldPrepender
 typealias Framing = LengthFieldBasedFrameDecoder
 
 /// Error indicating that after an operation some unused bytes are left.
-public struct LeftOverBytesError: Error {
+public struct LeftOverBytesError: Error, Sendable {
     public let leftOverBytes: ByteBuffer
 }
 
-private final class InitiatingHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+private final class InitiatingHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
     typealias OutboundOut = ByteBuffer
@@ -108,7 +109,8 @@ private final class InitiatingHandshakeHandler: ChannelInboundHandler, Removable
     }
 }
 
-final class ReceivingHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+final class ReceivingHandshakeHandler: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = Never
 
@@ -199,14 +201,15 @@ final class ReceivingHandshakeHandler: ChannelInboundHandler, RemovableChannelHa
     }
 }
 
-enum HandlerRole {
+enum HandlerRole: Sendable {
     case client
     case server
 }
 
 /// Will send `HandshakeMagicBytes` as the first two bytes for a new connection
 /// and remove itself from the pipeline afterwards.
-private final class ProtocolMagicBytesPrepender: ChannelOutboundHandler, RemovableChannelHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+private final class ProtocolMagicBytesPrepender: ChannelOutboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias OutboundIn = ByteBuffer
     typealias OutboundOut = ByteBuffer
 
@@ -222,7 +225,8 @@ private final class ProtocolMagicBytesPrepender: ChannelOutboundHandler, Removab
 
 /// Validates that the first two bytes for a new connection are equal to `HandshakeMagicBytes`
 /// and removes itself from the pipeline afterwards.
-private final class ProtocolMagicBytesValidator: ChannelInboundHandler, RemovableChannelHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+private final class ProtocolMagicBytesValidator: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
     typealias InboundOut = ByteBuffer
 
@@ -245,7 +249,8 @@ private final class ProtocolMagicBytesValidator: ChannelInboundHandler, Removabl
     }
 }
 
-private final class WireEnvelopeHandler: ChannelDuplexHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+private final class WireEnvelopeHandler: ChannelDuplexHandler, @unchecked Sendable {
     typealias OutboundIn = Wire.Envelope
     typealias OutboundOut = ByteBuffer
     typealias InboundIn = ByteBuffer
@@ -299,7 +304,8 @@ private final class WireEnvelopeHandler: ChannelDuplexHandler {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Outbound Message handler
 
-final class OutboundSerializationHandler: ChannelOutboundHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+final class OutboundSerializationHandler: ChannelOutboundHandler, @unchecked Sendable {
     typealias OutboundIn = TransportEnvelope
     typealias OutboundOut = Wire.Envelope
 
@@ -357,7 +363,8 @@ final class OutboundSerializationHandler: ChannelOutboundHandler {
 ///
 /// It follows the "Shell" pattern, all actual logic is implemented in the `OutboundSystemMessageRedelivery`
 /// and `InboundSystemMessages`
-internal final class SystemMessageRedeliveryHandler: ChannelDuplexHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+internal final class SystemMessageRedeliveryHandler: ChannelDuplexHandler, @unchecked Sendable {
     // we largely pass-through messages, however if they are system messages we keep them buffered for potential re-delivery
     typealias OutboundIn = TransportEnvelope
     typealias OutboundOut = TransportEnvelope
@@ -625,7 +632,8 @@ extension SystemMessageRedeliveryHandler {
 }
 
 /// Deserializes and delivers user messages (i.e. anything that is not a system message).
-private final class UserMessageHandler: ChannelInboundHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+private final class UserMessageHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = Wire.Envelope
     typealias InboundOut = Never  // we terminate here, by sending messages off to local actors
 
@@ -692,7 +700,8 @@ private final class UserMessageHandler: ChannelInboundHandler {
     }
 }
 
-private final class DumpRawBytesDebugHandler: ChannelInboundHandler {
+/// NIO ChannelHandler: all mutations occur on the owning EventLoop thread per NIO's threading contract.
+private final class DumpRawBytesDebugHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = ByteBuffer
 
     let role: HandlerRole
@@ -901,7 +910,9 @@ extension EventLoop {
 // MARK: TransportEnvelope
 
 /// Mirrors `Envelope` however ensures that the payload is a message; i.e. it cannot be a closure.
-internal struct TransportEnvelope: CustomStringConvertible, CustomDebugStringConvertible {
+/// @unchecked Sendable: Storage.message contains `Any` for type-erased actor messages.
+/// TransportEnvelopes are created and consumed within the NIO pipeline on EventLoop threads.
+internal struct TransportEnvelope: CustomStringConvertible, CustomDebugStringConvertible, @unchecked Sendable {
     let storage: Storage
     enum Storage {
         /// Note: MAY contain SystemMessageEnvelope
@@ -1003,6 +1014,6 @@ internal struct TransportEnvelope: CustomStringConvertible, CustomDebugStringCon
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Errors
 
-enum WireFormatError: Error {
+enum WireFormatError: Error, Sendable {
     case notEnoughBytes(expectedAtLeastBytes: Int, hint: String?)
 }

--- a/Sources/DistributedCluster/Cluster/Transport/WireMessages.swift
+++ b/Sources/DistributedCluster/Cluster/Transport/WireMessages.swift
@@ -12,20 +12,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-internal protocol WireMessage {}
+internal protocol WireMessage: Sendable {}
 
 /// The wire protocol data types are namespaced using this enum.
 ///
 /// When written onto they wire they are serialized to their transport specific formats (e.g. using protobuf or hand-rolled serializers).
 /// These models are intentionally detached from their serialized forms.
-internal enum Wire {
+internal enum Wire: Sendable {
     typealias Message = WireMessage
 
     /// The wire protocol version is the DistributedCluster version (at least now)
     public typealias Version = ClusterSystem.Version
 
     /// Envelope type carrying messages over the network.
-    struct Envelope: Codable {
+    struct Envelope: Codable, Sendable {
         /// This is a very blessed type hint, as it encapsulates all messages and is _assumed_ on the receiving end as the outer wrapper.
         static var typeHint: String = "_$Awe"  // Swift Actors wire envelope
 
@@ -39,14 +39,16 @@ internal enum Wire {
     }
 
     // TODO: such messages should go over a priority lane
-    internal struct HandshakeOffer: Equatable, WireMessage {
+    internal struct HandshakeOffer: Equatable, Sendable, WireMessage {
         internal var version: Version
 
         internal var originNode: Cluster.Node
         internal var targetEndpoint: Cluster.Endpoint
     }
 
-    internal enum HandshakeResponse: WireMessage {
+    // @unchecked Sendable: contains HandshakeAccept/Reject which hold non-Sendable closures
+    // (onHandshakeReplySent). These closures are only invoked on the NIO EventLoop thread.
+    internal enum HandshakeResponse: WireMessage, @unchecked Sendable {
         case accept(HandshakeAccept)
         case reject(HandshakeReject)
 
@@ -59,7 +61,8 @@ internal enum Wire {
         }
     }
 
-    internal struct HandshakeAccept: WireMessage {
+    // @unchecked Sendable: onHandshakeReplySent closure is non-Sendable but only invoked on the NIO EventLoop thread.
+    internal struct HandshakeAccept: WireMessage, @unchecked Sendable {
         internal let version: Version
         // TODO: Maybe offeringToSpeakAtVersion or something like that?
 
@@ -87,7 +90,8 @@ internal enum Wire {
     }
 
     /// Negative. We can not establish an association with this node.
-    internal struct HandshakeReject: WireMessage {
+    // @unchecked Sendable: onHandshakeReplySent closure is non-Sendable but only invoked on the NIO EventLoop thread.
+    internal struct HandshakeReject: WireMessage, @unchecked Sendable {
         internal let version: Version
         internal let reason: String
 

--- a/Sources/DistributedCluster/Cluster/Transport/WireMessages.swift
+++ b/Sources/DistributedCluster/Cluster/Transport/WireMessages.swift
@@ -27,7 +27,7 @@ internal enum Wire: Sendable {
     /// Envelope type carrying messages over the network.
     struct Envelope: Codable, Sendable {
         /// This is a very blessed type hint, as it encapsulates all messages and is _assumed_ on the receiving end as the outer wrapper.
-        static var typeHint: String = "_$Awe"  // Swift Actors wire envelope
+        static let typeHint: String = "_$Awe"  // Swift Actors wire envelope
 
         var recipient: ActorID
 

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -1328,14 +1328,18 @@ extension ClusterSystem {
         let callID = UUID()
 
         let timeout = RemoteCall.timeout ?? self.settings.remoteCall.defaultTimeout
-        let timeoutTask: Task<Void, Error> = Task.detached {
-            try await Task.sleep(nanoseconds: UInt64(timeout.nanoseconds))
+        nonisolated(unsafe) let unsafeTarget = target
+        nonisolated(unsafe) let unsafeTimeout = timeout
+        nonisolated(unsafe) let unsafeCallID = callID
+        nonisolated(unsafe) let unsafeActorID = actorID
+        let timeoutOperation: @Sendable () async throws -> Void = {
+            try await Task.sleep(nanoseconds: UInt64(unsafeTimeout.nanoseconds))
             guard !Task.isCancelled else {
                 return
             }
 
             self.inFlightCallLock.withLockVoid {
-                guard let continuation = self._inFlightCalls.removeValue(forKey: callID) else {
+                guard let continuation = self._inFlightCalls.removeValue(forKey: unsafeCallID) else {
                     // remoteCall was already completed successfully, nothing to do here
                     return
                 }
@@ -1350,21 +1354,22 @@ extension ClusterSystem {
                     //
                     // If we're shutting down, it is okay to not get acknowledgements to calls for example,
                     // and we don't care about them missing -- we're shutting down anyway.
-                    error = RemoteCallError(.clusterAlreadyShutDown, on: actorID, target: target)
+                    error = RemoteCallError(.clusterAlreadyShutDown, on: unsafeActorID, target: unsafeTarget)
                 } else {
                     error = RemoteCallError(
                         .timedOut(
-                            callID,
-                            TimeoutError(message: "Remote call [\(callID)] to [\(target)](\(actorID)) timed out", timeout: timeout)
+                            unsafeCallID,
+                            TimeoutError(message: "Remote call [\(unsafeCallID)] to [\(unsafeTarget)](\(unsafeActorID)) timed out", timeout: unsafeTimeout)
                         ),
-                        on: actorID,
-                        target: target
+                        on: unsafeActorID,
+                        target: unsafeTarget
                     )
                 }
 
                 continuation.resume(throwing: error)
             }
         }
+        let timeoutTask: Task<Void, Error> = Task.detached(operation: timeoutOperation)
         defer {
             timeoutTask.cancel()
         }
@@ -1427,25 +1432,30 @@ extension ClusterSystem {
             ]
         )
 
-        let anyReturn = try await withCheckedThrowingContinuation { cc in
-            Task { [invocation] in  // FIXME: make an async stream here since we lost ordering guarantees here
-                var directDecoder = ClusterInvocationDecoder(system: self, invocation: invocation)
-                let directReturnHandler = ClusterInvocationResultHandler(directReturnContinuation: cc)
+        nonisolated(unsafe) let unsafeInvocation = invocation
+        nonisolated(unsafe) let unsafeTarget = target
+        nonisolated(unsafe) let unsafeActor = actor
+        let anyReturn: Any = try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Any, Error>) in
+            nonisolated(unsafe) let unsafeCC = cc
+            let taskOperation: @Sendable () async throws -> Void = {
+                var directDecoder = ClusterInvocationDecoder(system: self, invocation: unsafeInvocation)
+                let directReturnHandler = ClusterInvocationResultHandler(directReturnContinuation: unsafeCC)
 
-                try await executeDistributedTarget(
-                    on: actor,
-                    target: target,
+                try await self.executeDistributedTarget(
+                    on: unsafeActor,
+                    target: unsafeTarget,
                     invocationDecoder: &directDecoder,
                     handler: directReturnHandler
                 )
             }
+            Task(operation: taskOperation)
         }
 
         guard let wellTypedReturn = anyReturn as? Res else {
             throw RemoteCallError(
                 .illegalReplyType(UUID(), expected: Res.self, got: type(of: anyReturn)),
                 on: actor.id,
-                target: target
+                target: unsafeTarget
             )
         }
 
@@ -1477,18 +1487,23 @@ extension ClusterSystem {
             ]
         )
 
+        nonisolated(unsafe) let unsafeInvocation = invocation
+        nonisolated(unsafe) let unsafeTarget = target
+        nonisolated(unsafe) let unsafeActor = actor
         _ = try await withCheckedThrowingContinuation { (cc: CheckedContinuation<Any, Error>) in
-            Task { [invocation] in
-                var directDecoder = ClusterInvocationDecoder(system: self, invocation: invocation)
-                let directReturnHandler = ClusterInvocationResultHandler(directReturnContinuation: cc)
+            nonisolated(unsafe) let unsafeCC = cc
+            let taskOperation: @Sendable () async throws -> Void = {
+                var directDecoder = ClusterInvocationDecoder(system: self, invocation: unsafeInvocation)
+                let directReturnHandler = ClusterInvocationResultHandler(directReturnContinuation: unsafeCC)
 
-                try await executeDistributedTarget(
-                    on: actor,
-                    target: target,
+                try await self.executeDistributedTarget(
+                    on: unsafeActor,
+                    target: unsafeTarget,
                     invocationDecoder: &directDecoder,
                     handler: directReturnHandler
                 )
             }
+            Task(operation: taskOperation)
         }
     }
 }
@@ -1551,7 +1566,8 @@ extension ClusterSystem {
                 self.log.warning("Missing continuation for remote call \(reply.callID). Reply will be dropped: \(reply)")  // this could be because remote call has timed out
                 return
             }
-            continuation.resume(returning: reply)
+            nonisolated(unsafe) let unsafeReply = reply
+            continuation.resume(returning: unsafeReply)
         }
     }
 
@@ -1654,7 +1670,8 @@ public struct ClusterInvocationResultHandler: DistributedTargetInvocationResultH
     public func onReturn<Success: Codable>(value: Success) async throws {
         switch self.state {
         case .localDirectReturn(let directReturnContinuation):
-            directReturnContinuation.resume(returning: value)
+            nonisolated(unsafe) let unsafeValue = value
+            directReturnContinuation.resume(returning: unsafeValue)
 
         case .remoteCall(let system, let callID, let channel, let recipient):
             system.log.trace(

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -29,6 +29,20 @@ import NIOPosix
 /// Rather, the system should be configured to host the kinds of dispatchers that the application needs.
 ///
 /// A `ClusterSystem` and all of the actors contained within remain alive until the `terminate` call is made.
+/// ## `@unchecked Sendable` Rationale
+///
+/// `ClusterSystem` is `@unchecked Sendable` because all mutable state is protected by explicit locks:
+///
+/// 1. **namingLock** (`Lock`) — Guards: `namingContext`, `_managedRefs`, `_managedDistributedActors`,
+///    `_reservedNames`, `_managedWellKnownDistributedActors`
+/// 2. **initLock** (`Lock`) — Guards lazy-init subsystem access: `_receptionistStore`, `_downingStrategyStore`,
+///    and double-check pattern for `_cluster`, `cluster`, `_nodeDeathWatcher`, `_receptionist`
+/// 3. **lazyInitializationLock** (`ReadWriteLock`) — Guards: `_serialization`
+/// 4. **inFlightCallLock** (`Lock`) — Guards: `_inFlightCalls`
+/// 5. **shutdownSemaphore** (`DispatchSemaphore`) — Guards shutdown sequencing
+///
+/// Remaining mutable fields (`_deadLetters`, `systemProvider`, `userProvider`, `_associationTombstoneCleanupTask`)
+/// are set once during `init` before the system is shared; see FIXME comments for Swift 6 verification.
 public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     public typealias InvocationDecoder = ClusterInvocationDecoder
     public typealias InvocationEncoder = ClusterInvocationEncoder
@@ -39,11 +53,13 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     public let name: String
 
     // initialized during startup
+    // FIXME: Swift 6 — verify concurrent access safety; set once during init, never mutated after
     internal var _deadLetters: _ActorRef<DeadLetter>!
 
     /// Impl note: Atomic since we are being called from outside actors here (or MAY be), thus we need to synchronize access
     /// Must be protected with `namingLock`
     internal var namingContext = ActorNamingContext()
+    // Guards: namingContext, _managedRefs, _managedDistributedActors, _reservedNames, _managedWellKnownDistributedActors
     internal let namingLock = Lock()
 
     internal func withNamingContext<T>(_ block: (inout ActorNamingContext) throws -> T) rethrows -> T {
@@ -54,8 +70,10 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
 
     // This lock is used to keep actors from accessing things like `system.cluster` before the cluster actor finished initializing.
     // TODO: collapse it with the other initialization lock; the other one is not needed now I think?
+    // Guards: _receptionistStore, _downingStrategyStore, and lazy-init double-check for _cluster, cluster, _nodeDeathWatcher, _receptionist
     private let initLock = Lock()
 
+    // FIXME: Swift 6 — verify concurrent access safety; set once during init, cancelled in shutdown
     private var _associationTombstoneCleanupTask: RepeatedTask?
 
     private let dispatcher: InternalMessageDispatcher
@@ -70,6 +88,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
 
     // TODO: converge into one tree
     // Note: This differs from Akka, we do full separate trees here
+    // FIXME: Swift 6 — verify concurrent access safety; set once during init under lazyInitializationLock, never mutated after
     private var systemProvider: _ActorRefProvider!
     private var userProvider: _ActorRefProvider!
 
@@ -80,6 +99,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     public let settings: ClusterSystemSettings
 
     // initialized during startup
+    // Guards: _serialization
     private let lazyInitializationLock: ReadWriteLock
 
     internal var _serialization: ManagedAtomicLazyReference<Serialization>
@@ -93,6 +113,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
         }
     }
 
+    // Guards: _inFlightCalls
     private let inFlightCallLock = Lock()
     private var _inFlightCalls: [CallID: CheckedContinuation<any AnyRemoteCallReply, Error>] = [:]
 
@@ -191,7 +212,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
 
     /// Greater than 0 shutdown has been initiated / is in progress.
     private let shutdownFlag: ManagedAtomic<Int> = .init(0)
-    internal var isShuttingDown: Bool {
+    nonisolated internal var isShuttingDown: Bool {
         self.shutdownFlag.load(ordering: .sequentiallyConsistent) > 0
     }
 
@@ -475,7 +496,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     }
 
     /// Returns `true` if the system was already successfully terminated (i.e. awaiting ``terminated`` would resume immediately).
-    public var isTerminated: Bool {
+    nonisolated public var isTerminated: Bool {
         self.shutdownFlag.load(ordering: .relaxed) > 0
     }
 

--- a/Sources/DistributedCluster/ClusterSystem.swift
+++ b/Sources/DistributedCluster/ClusterSystem.swift
@@ -456,7 +456,7 @@ public class ClusterSystem: DistributedActorSystem, @unchecked Sendable {
     }
 
     /// Object that can be awaited on until the system has completed shutting down.
-    public struct Shutdown {
+    public struct Shutdown: @unchecked Sendable {
         private let receptacle: BlockingReceptacle<Error?>
 
         init(receptacle: BlockingReceptacle<Error?>) {
@@ -1797,7 +1797,7 @@ struct RemoteCallReply<Value: Codable>: AnyRemoteCallReply {
     }
 }
 
-public struct GenericRemoteCallError: Error, Codable {
+public struct GenericRemoteCallError: Error, Codable, Sendable {
     public let message: String
 
     init(message: String) {
@@ -1809,7 +1809,7 @@ public struct GenericRemoteCallError: Error, Codable {
     }
 }
 
-public struct ClusterSystemError: DistributedActorSystemError, CustomStringConvertible {
+public struct ClusterSystemError: DistributedActorSystemError, CustomStringConvertible, @unchecked Sendable {
     internal enum _ClusterSystemError {
         case duplicateActorPath(path: ActorPath, existing: ActorID)
         case shuttingDown(String)
@@ -1841,7 +1841,7 @@ public struct ClusterSystemError: DistributedActorSystemError, CustomStringConve
 /// Error thrown when unable to resolve an ``ActorID``.
 ///
 /// Refer to ``ClusterSystem/resolve(id:as:)`` or the distributed actors Swift Evolution proposal for details.
-public struct ResolveError: DistributedActorSystemError, CustomStringConvertible {
+public struct ResolveError: DistributedActorSystemError, CustomStringConvertible, @unchecked Sendable {
     internal enum _ResolveError {
         case illegalIdentity(ClusterSystem.ActorID)
     }
@@ -1887,7 +1887,7 @@ internal struct LazyStart<Message: Codable> {
     }
 }
 
-public struct RemoteCallError: DistributedActorSystemError, CustomStringConvertible {
+public struct RemoteCallError: DistributedActorSystemError, CustomStringConvertible, @unchecked Sendable {
     internal enum _RemoteCallError {
         case clusterAlreadyShutDown
         case timedOut(ClusterSystem.CallID, TimeoutError)

--- a/Sources/DistributedCluster/ClusterSystemSettings.swift
+++ b/Sources/DistributedCluster/ClusterSystemSettings.swift
@@ -505,7 +505,7 @@ public struct ServiceDiscoverySettings {
 // MARK: Remote Call Settings
 
 extension ClusterSystemSettings {
-    public struct RemoteCallSettings {
+    public struct RemoteCallSettings: Sendable {
         public static var `default`: RemoteCallSettings {
             .init()
         }
@@ -517,8 +517,8 @@ extension ClusterSystemSettings {
 
         public var codableErrorAllowance: CodableErrorAllowanceSettings = .all
 
-        public struct CodableErrorAllowanceSettings {
-            internal enum CodableErrorAllowance {
+        public struct CodableErrorAllowanceSettings: Sendable {
+            internal enum CodableErrorAllowance: Sendable {
                 case none
                 case all
                 // OIDs of allowed types

--- a/Sources/DistributedCluster/Concurrency/_ClusterCancellableCheckedContinuation.swift
+++ b/Sources/DistributedCluster/Concurrency/_ClusterCancellableCheckedContinuation.swift
@@ -122,10 +122,11 @@ func _withClusterCancellableCheckedContinuation<Success>(
     function: String = #function
 ) async throws -> Success where Success: Sendable {
     let cccc = ClusterCancellableCheckedContinuation<Success>()
+    nonisolated(unsafe) let unsafeBody = body
     return try await withTaskCancellationHandler {
         try await withCheckedThrowingContinuation(function: function) { continuation in
             if cccc.setContinuation(continuation) {
-                body(cccc)
+                unsafeBody(cccc)
             }
         }
     } onCancel: {

--- a/Sources/DistributedCluster/Gossip/Gossip+Settings.swift
+++ b/Sources/DistributedCluster/Gossip/Gossip+Settings.swift
@@ -16,7 +16,9 @@
 // MARK: Gossiper Settings
 
 extension Gossiper {
-    struct Settings {
+    // @unchecked Sendable: PeerDiscovery.onClusterMember contains a non-@Sendable closure.
+    // Phase 3: make the resolve closure @Sendable.
+    struct Settings: @unchecked Sendable {
         /// Interval at which gossip rounds should proceed.
         ///
         /// - SeeAlso: `intervalRandomFactor`

--- a/Sources/DistributedCluster/Gossip/GossipLogic.swift
+++ b/Sources/DistributedCluster/Gossip/GossipLogic.swift
@@ -102,7 +102,9 @@ extension GossipLogic {
     }
 }
 
-struct GossipLogicContext<Envelope: Codable, Acknowledgement: Codable> {
+// @unchecked Sendable: Contains _ActorContext which is not Sendable. Context is only used
+// within the owning actor's mailbox. Phase 3: verify actor isolation.
+struct GossipLogicContext<Envelope: Codable, Acknowledgement: Codable>: @unchecked Sendable {
     /// Identifier associated with this gossip logic.
     ///
     /// Many gossipers only use a single identifier (and logic),
@@ -138,7 +140,9 @@ struct GossipLogicContext<Envelope: Codable, Acknowledgement: Codable> {
     }
 }
 
-struct AnyGossipLogic<Gossip: Codable, Acknowledgement: Codable>: GossipLogic, CustomStringConvertible {
+// @unchecked Sendable: Type-erased wrapper containing closures that capture mutable GossipLogic state.
+// Only accessed from within the owning GossipShell actor. Phase 3: verify actor isolation.
+struct AnyGossipLogic<Gossip: Codable, Acknowledgement: Codable>: GossipLogic, CustomStringConvertible, @unchecked Sendable {
     @usableFromInline
     let _selectPeers: ([_AddressableActorRef]) -> [_AddressableActorRef]
     @usableFromInline

--- a/Sources/DistributedCluster/Gossip/Gossiper+Shell.swift
+++ b/Sources/DistributedCluster/Gossip/Gossiper+Shell.swift
@@ -236,13 +236,14 @@ internal final class GossipShell<Gossip: Codable, Acknowledgement: Codable>: @un
                     continue
                 }
 
+                nonisolated(unsafe) let unsafeGossip = gossip
                 self.sendGossip(
                     context,
                     identifier: identifier,
                     gossip,
                     to: selectedRef,
                     onGossipAck: { ack in
-                        logic.receiveAcknowledgement(ack, from: selectedPeer, confirming: gossip)
+                        logic.receiveAcknowledgement(ack, from: selectedPeer, confirming: unsafeGossip)
                     }
                 )
             }
@@ -326,6 +327,7 @@ extension GossipShell {
             return  // nothing to do, peers will be introduced manually
 
         case .onClusterMember(let atLeastStatus, let resolvePeerOn):
+            nonisolated(unsafe) let resolvePeerOn = resolvePeerOn
             @Sendable func resolveInsertPeer(_ context: _ActorContext<Message>, member: Cluster.Member) {
                 guard member.node != context.system.cluster.node else {
                     return  // ignore self node

--- a/Sources/DistributedCluster/Gossip/Gossiper+Shell.swift
+++ b/Sources/DistributedCluster/Gossip/Gossiper+Shell.swift
@@ -17,7 +17,9 @@ import Logging
 private let gossipTickKey: _TimerKey = "gossip-tick"
 
 /// Not intended to be spawned directly, use `Gossiper.spawn` instead!
-internal final class GossipShell<Gossip: Codable, Acknowledgement: Codable> {
+// @unchecked Sendable: Mutable state is only accessed from within the actor's mailbox run.
+// Phase 3: verify single-threaded access pattern before removing @unchecked.
+internal final class GossipShell<Gossip: Codable, Acknowledgement: Codable>: @unchecked Sendable {
     typealias Ref = _ActorRef<Message>
 
     let settings: Gossiper.Settings

--- a/Sources/DistributedCluster/Gossip/Gossiper+Shell.swift
+++ b/Sources/DistributedCluster/Gossip/Gossiper+Shell.swift
@@ -48,6 +48,7 @@ internal final class GossipShell<Gossip: Codable, Acknowledgement: Codable>: @un
 
     var behavior: _Behavior<Message> {
         .setup { context in
+            nonisolated(unsafe) let context = context
             self.ensureNextGossipRound(context)
             self.initPeerDiscovery(context)
 
@@ -256,7 +257,7 @@ internal final class GossipShell<Gossip: Codable, Acknowledgement: Codable>: @un
         identifier: AnyGossipIdentifier,
         _ payload: Gossip,
         to target: PeerRef,
-        onGossipAck: @escaping (Acknowledgement) -> Void
+        onGossipAck: @escaping @Sendable (Acknowledgement) -> Void
     ) {
         context.log.trace(
             "Sending gossip to \(target.id)",
@@ -325,7 +326,7 @@ extension GossipShell {
             return  // nothing to do, peers will be introduced manually
 
         case .onClusterMember(let atLeastStatus, let resolvePeerOn):
-            func resolveInsertPeer(_ context: _ActorContext<Message>, member: Cluster.Member) {
+            @Sendable func resolveInsertPeer(_ context: _ActorContext<Message>, member: Cluster.Member) {
                 guard member.node != context.system.cluster.node else {
                     return  // ignore self node
                 }

--- a/Sources/DistributedCluster/Gossip/Gossiper.swift
+++ b/Sources/DistributedCluster/Gossip/Gossiper.swift
@@ -54,7 +54,9 @@ enum Gossiper {
 // MARK: GossiperControl
 
 /// Control object used to modify and interact with a spawned `Gossiper<Gossip, Acknowledgement>`.
-struct GossiperControl<Gossip: Codable, Acknowledgement: Codable> {
+// @unchecked Sendable: Contains _ActorRef which is Sendable, but generic constraints prevent
+// the compiler from proving it. Phase 3: add Sendable constraints to Gossip/Acknowledgement.
+struct GossiperControl<Gossip: Codable, Acknowledgement: Codable>: @unchecked Sendable {
     /// Internal FOR TESTING ONLY.
     internal let ref: GossipShell<Gossip, Acknowledgement>.Ref
 
@@ -99,7 +101,9 @@ protocol GossipIdentifier {
     var asAnyGossipIdentifier: AnyGossipIdentifier { get }
 }
 
-struct AnyGossipIdentifier: Hashable, GossipIdentifier {
+// @unchecked Sendable: Wraps a GossipIdentifier protocol value. All known implementations
+// (StringGossipIdentifier) are value types with Sendable properties.
+struct AnyGossipIdentifier: Hashable, GossipIdentifier, @unchecked Sendable {
     let underlying: GossipIdentifier
 
     init(_ id: String) {
@@ -131,7 +135,7 @@ struct AnyGossipIdentifier: Hashable, GossipIdentifier {
     }
 }
 
-struct StringGossipIdentifier: GossipIdentifier, Hashable, ExpressibleByStringLiteral, CustomStringConvertible {
+struct StringGossipIdentifier: GossipIdentifier, Hashable, ExpressibleByStringLiteral, CustomStringConvertible, Sendable {
     let gossipIdentifier: String
 
     init(_ gossipIdentifier: StringLiteralType) {

--- a/Sources/DistributedCluster/InvocationBehavior.swift
+++ b/Sources/DistributedCluster/InvocationBehavior.swift
@@ -37,8 +37,10 @@ public struct InvocationMessage: Sendable, Codable, CustomStringConvertible {
 // FIXME(distributed): remove [#957](https://github.com/apple/swift-distributed-actors/issues/957)
 enum InvocationBehavior {
     static func behavior(instance weakInstance: WeakLocalRef<some DistributedActor>) -> _Behavior<InvocationMessage> {
-        _Behavior.setup { context in
-            ._receiveMessageAsync { (message) async throws -> _Behavior<InvocationMessage> in
+        nonisolated(unsafe) let weakInstance = weakInstance
+        return _Behavior.setup { context in
+            nonisolated(unsafe) let context = context
+            return ._receiveMessageAsync { (message) async throws -> _Behavior<InvocationMessage> in
                 guard let _ = weakInstance.actor else {
                     context.log.warning("Received message \(message) while distributed actor instance was released! Stopping...")
                     context.system.personalDeadLetters(type: InvocationMessage.self, recipient: context.id).tell(message)
@@ -58,6 +60,7 @@ enum InvocationBehavior {
 
                 if let terminated = signal as? _Signals.Terminated {
                     if let watcher = instance as? (any LifecycleWatch) {
+                        nonisolated(unsafe) let watcher = watcher
                         Task {
                             await watcher.whenLocal { __secretlyKnownToBeLocalK in
                                 let __secretlyKnownToBeLocal: any LifecycleWatch = __secretlyKnownToBeLocalK

--- a/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatchContainer.swift
+++ b/Sources/DistributedCluster/LifecycleMonitoring/LifecycleWatchContainer.swift
@@ -26,7 +26,8 @@ import NIO
 /// Termination of local actors is simply whenever they deinitialize.
 /// Remote actors are considered terminated when they deinitialize, same as local actors,
 /// or when the node hosting them is declared `.down`.
-final class LifecycleWatchContainer {
+// @unchecked Sendable: Thread safety is provided by _lock (DispatchSemaphore) guarding all mutable state.
+final class LifecycleWatchContainer: @unchecked Sendable {
     private let _lock = DispatchSemaphore(value: 1)
 
     internal let watcherID: ClusterSystem.ActorID

--- a/Sources/DistributedCluster/Pattern/WorkerPool.swift
+++ b/Sources/DistributedCluster/Pattern/WorkerPool.swift
@@ -152,7 +152,7 @@ public distributed actor WorkerPool<Worker: DistributedWorker>: DistributedWorke
                 (true, .awaitNewWorkers):
                 self.log.log(level: self.logLevel, "Worker pool is empty, waiting for new worker.")
 
-                try await _withClusterCancellableCheckedContinuation(of: Void.self) { cccc in
+                let closureBody: (ClusterCancellableCheckedContinuation<Void>) -> Void = { cccc in
                     self.newWorkerContinuations.append(cccc)
                     let log = self.log
                     cccc.onCancel { cccc in
@@ -163,6 +163,8 @@ public distributed actor WorkerPool<Worker: DistributedWorker>: DistributedWorke
                         }
                     }
                 }
+                nonisolated(unsafe) let unsafeClosureBody = closureBody
+                try await _withClusterCancellableCheckedContinuation(of: Void.self, unsafeClosureBody)
             case (true, .throw(let error)):
                 throw error
             }

--- a/Sources/DistributedCluster/Pattern/WorkerPool.swift
+++ b/Sources/DistributedCluster/Pattern/WorkerPool.swift
@@ -293,8 +293,9 @@ extension WorkerPool {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: WorkerPool Errors
 
-public struct WorkerPoolError: Error, CustomStringConvertible {
-    internal enum _WorkerPoolError {
+// @unchecked Sendable: _Storage is a class but is immutable after init (all let bindings).
+public struct WorkerPoolError: Error, CustomStringConvertible, @unchecked Sendable {
+    internal enum _WorkerPoolError: Sendable {
         // --- runtime errors
         case staticPoolExhausted(String)
 
@@ -303,7 +304,8 @@ public struct WorkerPoolError: Error, CustomStringConvertible {
         case illegalAwaitNewWorkersForStaticPoolConfigured(String)
     }
 
-    internal class _Storage {
+    // @unchecked Sendable: all stored properties are immutable after init (let bindings).
+    internal class _Storage: @unchecked Sendable {
         let error: _WorkerPoolError
         let file: String
         let line: UInt

--- a/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonBoss.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonBoss.swift
@@ -566,8 +566,12 @@ struct ClusterSingletonRemoteCallInterceptor<Singleton: ClusterSingleton>: Remot
         }
 
         let invocation = invocation  // can't capture inout param
+        // Capture metatypes as local lets to silence Swift 6 non-Sendable capture warnings.
+        // Metatypes are inherently safe to share across concurrency boundaries.
+        let throwingType = throwing
+        nonisolated(unsafe) let returningType = returning
         let result = try await self.singletonBoss.whenLocal { __secretlyKnownToBeLocal in  // TODO(distributed): this is annoying, we must track "known to be local" in typesystem instead
-            try await __secretlyKnownToBeLocal.forwardOrStashRemoteCall(target: target, invocation: invocation, throwing: throwing, returning: returning)
+            try await __secretlyKnownToBeLocal.forwardOrStashRemoteCall(target: target, invocation: invocation, throwing: throwingType, returning: returningType)
         }
 
         guard let result = result else {

--- a/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonBoss.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonBoss.swift
@@ -18,6 +18,13 @@ import Logging
 import struct Foundation.Data
 import struct Foundation.UUID
 
+/// Box to bridge non-Sendable values across isolation boundaries where safety is
+/// guaranteed by the runtime (e.g., `whenLocal` on a known-local distributed actor).
+internal struct UnsafeSendableBox<T>: @unchecked Sendable {
+    let value: T
+    init(_ value: T) { self.value = value }
+}
+
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Cluster singleton boss
 
@@ -117,7 +124,8 @@ internal distributed actor ClusterSingletonBoss<Act: ClusterSingleton>: ClusterS
     private func receiveClusterEvent(_ event: Cluster.Event) async throws {
         // Feed the event to `AllocationStrategy` then forward the result to `updateTargetNode`,
         // which will determine if `targetNode` has changed and react accordingly.
-        let node = await self.allocationStrategy.onClusterEvent(event)
+        nonisolated(unsafe) let strategy = self.allocationStrategy
+        let node = await strategy.onClusterEvent(event)
         try await self.updateTargetNode(node: node)
     }
 
@@ -200,6 +208,9 @@ internal distributed actor ClusterSingletonBoss<Act: ClusterSingleton>: ClusterS
             targetSingletonBossID.path = self.id.path
             let targetSingletonBoss = try Self.resolve(id: targetSingletonBossID, using: self.actorSystem)
 
+            nonisolated(unsafe) let unsafeSelf = self
+            let settingsName = self.settings.name
+            let selfPath = self.id.path
             let targetSingleton: Act = try await Backoff.exponential(
                 initialInterval: settings.locateActiveSingletonBackoff.initialInterval,
                 multiplier: settings.locateActiveSingletonBackoff.multiplier,
@@ -210,17 +221,17 @@ internal distributed actor ClusterSingletonBoss<Act: ClusterSingleton>: ClusterS
                 // confirm tha the boss is hosting the singleton, if not we may have to wait and try again
                 do {
                     guard (try? await targetSingletonBoss.hasActiveSingleton()) ?? false else {
-                        throw SingletonNotFoundNoExpectedNode(id: self.settings.name, node)
+                        throw SingletonNotFoundNoExpectedNode(id: settingsName, node)
                     }
                 } catch {
                     throw error
                 }
 
                 var targetSingletonID = ActorID(remote: otherNode, type: Self.self, incarnation: .wellKnown)
-                targetSingletonID.metadata.wellKnown = self.settings.name
-                targetSingletonID.path = self.id.path
+                targetSingletonID.metadata.wellKnown = settingsName
+                targetSingletonID.path = selfPath
 
-                return try Act.resolve(id: targetSingletonID, using: self.actorSystem)
+                return try Act.resolve(id: targetSingletonID, using: unsafeSelf.actorSystem)
             }
             self.updateSingleton(targetSingleton)
 
@@ -465,7 +476,8 @@ extension ClusterSingletonBoss {
                 ])
             )
 
-            var invocation = invocation  // can't be inout param
+            nonisolated(unsafe) var invocation = invocation  // can't be inout param
+            nonisolated(unsafe) let unsafeTarget = target
             if targetNode == selfNode,
                 let singleton = self.targetSingleton
             {
@@ -475,7 +487,7 @@ extension ClusterSingletonBoss {
                 )
                 return try await singleton.actorSystem.localCall(
                     on: singleton,
-                    target: target,
+                    target: unsafeTarget,
                     invocation: &invocation,
                     throwing: throwing,
                     returning: returning
@@ -484,7 +496,7 @@ extension ClusterSingletonBoss {
 
             return try await singleton.actorSystem.remoteCall(
                 on: singleton,
-                target: target,
+                target: unsafeTarget,
                 invocation: &invocation,
                 throwing: throwing,
                 returning: returning
@@ -517,11 +529,12 @@ extension ClusterSingletonBoss {
             ])
         )
 
-        var invocation = invocation  // can't be inout param
+        nonisolated(unsafe) var invocation = invocation  // can't be inout param
+        nonisolated(unsafe) let unsafeTarget = target
         if targetNode == selfNode,
             let singleton = self.targetSingleton
         {
-            self.log.trace("ENTER forwardOrStashRemoteCallVoid \(target) -> DIRECT LOCAL CALL")
+            self.log.trace("ENTER forwardOrStashRemoteCallVoid \(unsafeTarget) -> DIRECT LOCAL CALL")
 
             assert(
                 singleton.id.node == selfNode,
@@ -529,7 +542,7 @@ extension ClusterSingletonBoss {
             )
             return try await singleton.actorSystem.localCallVoid(
                 on: singleton,
-                target: target,
+                target: unsafeTarget,
                 invocation: &invocation,
                 throwing: throwing
             )
@@ -537,7 +550,7 @@ extension ClusterSingletonBoss {
 
         return try await singleton.actorSystem.remoteCallVoid(
             on: singleton,
-            target: target,
+            target: unsafeTarget,
             invocation: &invocation,
             throwing: throwing
         )
@@ -570,14 +583,17 @@ struct ClusterSingletonRemoteCallInterceptor<Singleton: ClusterSingleton>: Remot
         // Metatypes are inherently safe to share across concurrency boundaries.
         let throwingType = throwing
         nonisolated(unsafe) let returningType = returning
-        let result = try await self.singletonBoss.whenLocal { __secretlyKnownToBeLocal in  // TODO(distributed): this is annoying, we must track "known to be local" in typesystem instead
-            try await __secretlyKnownToBeLocal.forwardOrStashRemoteCall(target: target, invocation: invocation, throwing: throwingType, returning: returningType)
+        nonisolated(unsafe) let unsafeTarget = target
+        nonisolated(unsafe) let unsafeInvocation = invocation
+        let wrappedResult: UnsafeSendableBox<Res>? = try await self.singletonBoss.whenLocal { __secretlyKnownToBeLocal in  // TODO(distributed): this is annoying, we must track "known to be local" in typesystem instead
+            let res: Res = try await __secretlyKnownToBeLocal.forwardOrStashRemoteCall(target: unsafeTarget, invocation: unsafeInvocation, throwing: throwingType, returning: returningType)
+            return UnsafeSendableBox(res)
         }
 
-        guard let result = result else {
+        guard let wrappedResult else {
             fatalError("Unexpected remote call")
         }
-        return result
+        return wrappedResult.value
     }
 
     func interceptRemoteCallVoid<Act, Err>(
@@ -596,8 +612,10 @@ struct ClusterSingletonRemoteCallInterceptor<Singleton: ClusterSingleton>: Remot
         }
 
         let invocation = invocation  // can't capture inout param
+        nonisolated(unsafe) let unsafeTarget = target
+        nonisolated(unsafe) let unsafeInvocation = invocation
         try await self.singletonBoss.whenLocal { __secretlyKnownToBeLocal in  // TODO(distributed): this is annoying, we must track "known to be local" in typesystem instead
-            try await __secretlyKnownToBeLocal.forwardOrStashRemoteCallVoid(target: target, invocation: invocation, throwing: throwing)
+            try await __secretlyKnownToBeLocal.forwardOrStashRemoteCallVoid(target: unsafeTarget, invocation: unsafeInvocation, throwing: throwing)
         }
     }
 }

--- a/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonPlugin.swift
+++ b/Sources/DistributedCluster/Plugins/ClusterSingleton/ClusterSingletonPlugin.swift
@@ -115,6 +115,7 @@ extension ClusterSingletonPlugin: Plugin {
     public func stop(_ system: ClusterSystem) async {
         self.actorSystem = nil
         for (_, (_, boss)) in self.singletons {
+            nonisolated(unsafe) let boss = boss
             await boss.stop()
         }
     }

--- a/Sources/DistributedCluster/Props+Metrics.swift
+++ b/Sources/DistributedCluster/Props+Metrics.swift
@@ -51,7 +51,7 @@ extension _Props {
     }
 }
 
-public struct MetricsProps: CustomStringConvertible {
+public struct MetricsProps: CustomStringConvertible, Sendable {
     /// Set of built-in active metrics
     public var active: ActiveMetricsOptionSet
 
@@ -77,7 +77,7 @@ public struct MetricsProps: CustomStringConvertible {
 }
 
 /// Defines which per actor (group) metrics are enabled for a given actor.
-public struct ActiveMetricsOptionSet: OptionSet {
+public struct ActiveMetricsOptionSet: OptionSet, Sendable {
     public let rawValue: Int
 
     public init(rawValue: Int) {

--- a/Sources/DistributedCluster/Props.swift
+++ b/Sources/DistributedCluster/Props.swift
@@ -29,7 +29,8 @@ import NIO
 /// For example, a skull would be a classic example of a "prop" used while performing the William Shakespeare's
 /// Hamlet Act III, scene 1, saying "To be, or not to be, that is the question: [...]." In the same sense,
 /// props for Swift Distributed Actors are accompanying objects/settings, which help the actor perform its duties.
-// @unchecked required: contains ActorMetadata (class) and _DispatcherProps (holds non-Sendable DispatchQueue/EventLoopGroup)
+// @unchecked required: _DispatcherProps holds non-Sendable DispatchQueue (Dispatch) and EventLoopGroup (NIO).
+// ActorMetadata is now @unchecked Sendable with lock-based synchronization (Phase 2).
 public struct _Props: @unchecked Sendable {
     internal var dispatcher: _DispatcherProps = .default
 
@@ -122,9 +123,8 @@ public struct _Props: @unchecked Sendable {
 /// These props must be used during `_spawn` which happens on `actorReady`.
 ///
 /// This is somewhat of a relict of ActorRef infrastructure and should eventually be removed.
-// Phase 2: @unchecked required: stores _Props, which is itself @unchecked Sendable because it holds
-// ActorMetadata (class) and _DispatcherProps (contains non-Sendable DispatchQueue/EventLoopGroup).
-// Address the root cause in _Props (and ActorMetadata) first.
+// @unchecked required: stores _Props which is @unchecked Sendable due to _DispatcherProps
+// holding non-Sendable DispatchQueue/EventLoopGroup. ActorMetadata is now @unchecked Sendable (Phase 2).
 struct _PropsShuttle: @unchecked Sendable, Codable {
     let props: _Props
     init(props: _Props) {

--- a/Sources/DistributedCluster/Protobuf/ActorID.pb.swift
+++ b/Sources/DistributedCluster/Protobuf/ActorID.pb.swift
@@ -146,7 +146,7 @@ extension _ProtoActorID: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
         var _incarnation: UInt32 = 0
         var _metadata: [String: Data] = [:]
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -256,7 +256,7 @@ extension _ProtoClusterNode: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
         var _endpoint: _ProtoClusterEndpoint? = nil
         var _nid: UInt64 = 0
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Protobuf/SystemMessages.pb.swift
+++ b/Sources/DistributedCluster/Protobuf/SystemMessages.pb.swift
@@ -246,7 +246,7 @@ extension _ProtoSystemMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImpl
     fileprivate class _StorageClass {
         var _payload: _ProtoSystemMessage.OneOf_Payload?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -338,7 +338,7 @@ extension _ProtoSystemMessage_Watch: SwiftProtobuf.Message, SwiftProtobuf._Messa
         var _watchee: _ProtoActorID? = nil
         var _watcher: _ProtoActorID? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -407,7 +407,7 @@ extension _ProtoSystemMessage_Unwatch: SwiftProtobuf.Message, SwiftProtobuf._Mes
         var _watchee: _ProtoActorID? = nil
         var _watcher: _ProtoActorID? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -478,7 +478,7 @@ extension _ProtoSystemMessage_Terminated: SwiftProtobuf.Message, SwiftProtobuf._
         var _existenceConfirmed: Bool = false
         var _idTerminated: Bool = false
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -611,7 +611,7 @@ extension _ProtoSystemMessageEnvelope: SwiftProtobuf.Message, SwiftProtobuf._Mes
         var _sequenceNr: UInt64 = 0
         var _message: _ProtoSystemMessage? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Protobuf/WireProtocol.pb.swift
+++ b/Sources/DistributedCluster/Protobuf/WireProtocol.pb.swift
@@ -353,7 +353,7 @@ extension _ProtoHandshakeOffer: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
         var _originNode: _ProtoClusterNode? = nil
         var _targetEndpoint: _ProtoClusterEndpoint? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -427,7 +427,7 @@ extension _ProtoHandshakeResponse: SwiftProtobuf.Message, SwiftProtobuf._Message
     fileprivate class _StorageClass {
         var _status: _ProtoHandshakeResponse.OneOf_Status?
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -511,7 +511,7 @@ extension _ProtoHandshakeAccept: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
         var _originNode: _ProtoClusterNode? = nil
         var _targetNode: _ProtoClusterNode? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -590,7 +590,7 @@ extension _ProtoHandshakeReject: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
         var _targetNode: _ProtoClusterNode? = nil
         var _reason: String = String()
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -673,7 +673,7 @@ extension _ProtoEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
         var _manifest: _ProtoManifest? = nil
         var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -752,7 +752,7 @@ extension _ProtoSystemEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageImp
         var _manifest: _ProtoManifest? = nil
         var _payload: Data = SwiftProtobuf.Internal.emptyData
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 
@@ -833,7 +833,7 @@ extension _ProtoSystemAck: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
         var _sequenceNr: UInt64 = 0
         var _from: _ProtoClusterNode? = nil
 
-        static let defaultInstance = _StorageClass()
+        nonisolated(unsafe) static let defaultInstance = _StorageClass()
 
         private init() {}
 

--- a/Sources/DistributedCluster/Receptionist/DistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/DistributedReceptionist.swift
@@ -162,7 +162,7 @@ extension DistributedReception {
 /// This allows a local subscriber to definitely compare a registration with its "already seen"
 /// version vector (that contains versions for every node it is receiving updates from),
 /// and only emit those to the user-facing stream which have not been observed yet.
-internal struct VersionedRegistration: Hashable {
+internal struct VersionedRegistration: Hashable, Sendable {
     let version: VersionVector
     let actorID: ClusterSystem.ActorID
 
@@ -188,7 +188,9 @@ internal struct VersionedRegistration: Hashable {
     }
 }
 
-internal final class DistributedReceptionistStorage {
+// @unchecked Sendable: Storage is only accessed from within the owning distributed actor (OpLogDistributedReceptionist).
+// Phase 3: verify actor isolation before removing @unchecked.
+internal final class DistributedReceptionistStorage: @unchecked Sendable {
     typealias ReceptionistOp = OpLogDistributedReceptionist.ReceptionistOp
 
     internal var _registrations: [AnyDistributedReceptionKey: OrderedSet<VersionedRegistration>] = [:]

--- a/Sources/DistributedCluster/Receptionist/DistributedReceptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/DistributedReceptionist.swift
@@ -98,7 +98,10 @@ extension DistributedReception {
             AsyncIterator(receptionist: self.receptionist, key: self.key, file: self.file, line: self.line)
         }
 
-        public class AsyncIterator: AsyncIteratorProtocol {
+        // @unchecked Sendable: The underlying AsyncStream.Iterator is accessed only sequentially
+        // through the AsyncIteratorProtocol's next() method. The mutable `underlying` property is
+        // set once during init and then only read via next().
+        public class AsyncIterator: AsyncIteratorProtocol, @unchecked Sendable {
             var underlying: AsyncStream<Element>.Iterator!
 
             init(

--- a/Sources/DistributedCluster/Receptionist/Receptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/Receptionist.swift
@@ -36,7 +36,7 @@ public struct Receptionist {
 
     /// INTERNAL API
     /// When sent to receptionist will register the specified `_ActorRef` under the given `_Reception.Key`
-    public class Register<Guest: _ReceptionistGuest>: _AnyRegister {
+    public class Register<Guest: _ReceptionistGuest>: _AnyRegister, @unchecked Sendable {
         public let guest: Guest
         public let key: _Reception.Key<Guest>
         public let replyTo: _ActorRef<_Reception.Registered<Guest>>?
@@ -71,7 +71,7 @@ public struct Receptionist {
 
     /// INTERNAL API
     /// Used to lookup `_ActorRef`s for the given `_Reception.Key`
-    public class Lookup<Guest: _ReceptionistGuest>: _Lookup, ListingRequest, CustomStringConvertible {
+    public class Lookup<Guest: _ReceptionistGuest>: _Lookup, ListingRequest, CustomStringConvertible, @unchecked Sendable {
         public let key: _Reception.Key<Guest>
         public let subscriber: _ActorRef<_Reception.Listing<Guest>>
 
@@ -96,7 +96,7 @@ public struct Receptionist {
 
     /// INTERNAL API
     /// Subscribe to periodic updates of the specified key
-    public class Subscribe<Guest: _ReceptionistGuest>: _Subscribe, ListingRequest, CustomStringConvertible {
+    public class Subscribe<Guest: _ReceptionistGuest>: _Subscribe, ListingRequest, CustomStringConvertible, @unchecked Sendable {
         public let key: _Reception.Key<Guest>
         public let subscriber: _ActorRef<_Reception.Listing<Guest>>
 
@@ -373,7 +373,7 @@ public class _ReceptionistMessage: Codable, @unchecked Sendable {}
 internal typealias FullyQualifiedTypeName = String
 
 /// INTERNAL API
-public class _AnyRegister: _ReceptionistMessage, _NotActuallyCodableMessage, CustomStringConvertible {
+public class _AnyRegister: _ReceptionistMessage, _NotActuallyCodableMessage, CustomStringConvertible, @unchecked Sendable {
     var _addressableActorRef: _AddressableActorRef { _undefined() }
     var _key: AnyReceptionKey { _undefined() }
 
@@ -386,7 +386,7 @@ public class _AnyRegister: _ReceptionistMessage, _NotActuallyCodableMessage, Cus
     }
 }
 
-public class _Lookup: _ReceptionistMessage, _NotActuallyCodableMessage {
+public class _Lookup: _ReceptionistMessage, _NotActuallyCodableMessage, @unchecked Sendable {
     let _key: AnyReceptionKey
 
     init(_key: AnyReceptionKey) {
@@ -492,7 +492,7 @@ public struct AnyReceptionKey: ReceptionKeyProtocol, Sendable, Codable, Hashable
     }
 }
 
-public class _Subscribe: _ReceptionistMessage, _NotActuallyCodableMessage {
+public class _Subscribe: _ReceptionistMessage, _NotActuallyCodableMessage, @unchecked Sendable {
     var _key: AnyReceptionKey {
         fatalErrorBacktrace("failed \(#function)")
     }
@@ -554,7 +554,7 @@ internal protocol ListingRequest {
     func replyWith(_ refs: Set<_AddressableActorRef>)
 }
 
-internal final class _ReceptionistDelayedListingFlushTick: _ReceptionistMessage, _NotActuallyCodableMessage {
+internal final class _ReceptionistDelayedListingFlushTick: _ReceptionistMessage, _NotActuallyCodableMessage, @unchecked Sendable {
     let key: AnyReceptionKey
 
     init(key: AnyReceptionKey) {

--- a/Sources/DistributedCluster/Receptionist/Receptionist.swift
+++ b/Sources/DistributedCluster/Receptionist/Receptionist.swift
@@ -132,7 +132,9 @@ public struct Receptionist {
     }
 
     /// Storage container for a receptionist's registrations and subscriptions
-    internal final class Storage {
+    // @unchecked Sendable: Storage is only accessed from within the owning actor's mailbox run.
+    // Phase 3: verify single-threaded access pattern before removing @unchecked.
+    internal final class Storage: @unchecked Sendable {
         internal var _registrations: [AnyReceptionKey: Set<_AddressableActorRef>] = [:]
         internal var _subscriptions: [AnyReceptionKey: Set<AnySubscribe>] = [:]
 
@@ -512,7 +514,9 @@ public class _Subscribe: _ReceptionistMessage, _NotActuallyCodableMessage {
     }
 }
 
-internal struct AnySubscribe: Hashable {
+// @unchecked Sendable: Contains a non-@Sendable closure (_replyWith). The closure captures _ActorRef.tell
+// which is thread-safe. Phase 3: make _replyWith @Sendable.
+internal struct AnySubscribe: Hashable, @unchecked Sendable {
     let id: ActorID
     let _replyWith: (Set<_AddressableActorRef>) -> Void
 

--- a/Sources/DistributedCluster/Refs+any.swift
+++ b/Sources/DistributedCluster/Refs+any.swift
@@ -28,7 +28,9 @@ import protocol NIO.EventLoop
 /// This enables an `_AddressableActorRef` to be useful for watching, storing and comparing actor references of various types with another.
 /// Note that unlike a plain `ActorID` an `_AddressableActorRef` still DOES hold an actual reference to the pointed to actor,
 /// even though it is not able to send messages to it (due to the lack of type-safety when doing so).
-public struct _AddressableActorRef: _DeathWatchable, Hashable {
+// @unchecked Sendable: wraps _ActorRef which is already @unchecked Sendable.
+// The underlying ref is thread-safe via mailbox/actor model.
+public struct _AddressableActorRef: _DeathWatchable, Hashable, @unchecked Sendable {
     @usableFromInline
     enum RefType {
         case remote

--- a/Sources/DistributedCluster/Scheduler.swift
+++ b/Sources/DistributedCluster/Scheduler.swift
@@ -57,7 +57,9 @@ final class FlagCancelable: Cancelable, @unchecked Sendable {
     }
 }
 
-extension DispatchWorkItem: @retroactive Cancelable {
+// @unchecked Sendable: DispatchWorkItem is from Dispatch and is safe to use across concurrency boundaries.
+// Cancelable is an in-module protocol so no @retroactive needed.
+extension DispatchWorkItem: Cancelable, @retroactive @unchecked Sendable {
     @usableFromInline
     var isCanceled: Bool {
         self.isCancelled
@@ -65,7 +67,7 @@ extension DispatchWorkItem: @retroactive Cancelable {
 }
 
 // TODO: this is mostly only a placeholder impl; we'd need a proper wheel timer most likely
-extension DispatchQueue: Scheduler, @unchecked Sendable {
+extension DispatchQueue: Scheduler {
     func scheduleOnce(delay: Duration, _ f: @escaping () -> Void) -> Cancelable {
         let workItem = DispatchWorkItem(block: f)
         self.asyncAfter(deadline: .init(nowDelayedBy: delay), execute: workItem)

--- a/Sources/DistributedCluster/Serialization/Serialization+Context.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization+Context.swift
@@ -26,7 +26,8 @@ extension Serialization {
     /// A context object provided to any `Swift/Encoder`/`Swift/Decoder` used during remoteCall message serialization
     ///
     /// `Serialization.Context` may be accessed concurrently be encoders/decoders.
-    public struct Context {
+    // Sendable: Logger, ClusterSystem (@unchecked Sendable), and ByteBufferAllocator are all Sendable.
+    public struct Context: Sendable {
         public let log: Logger
         public let system: ClusterSystem
 

--- a/Sources/DistributedCluster/Serialization/Serialization+Manifest.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization+Manifest.swift
@@ -31,7 +31,7 @@ extension Serialization {
     /// payload into the "right" type. Some serializers may not need hints, e.g. if the serializer is specialized to a
     /// specific type already -- in those situations not carrying the type `hint` is recommended as it may save precious
     /// bytes from the message envelope size on the wire.
-    public struct Manifest: Codable, Hashable {
+    public struct Manifest: Codable, Hashable, Sendable {
         /// Serializer used to serialize accompanied message.
         public let serializerID: SerializerID
 

--- a/Sources/DistributedCluster/Serialization/Serialization+SerializerID.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization+SerializerID.swift
@@ -16,7 +16,7 @@ import SWIM
 
 extension Serialization {
     /// Used to identify a type (or instance) of a `Serializer`.
-    public struct SerializerID: ExpressibleByIntegerLiteral, Hashable, Comparable, CustomStringConvertible {
+    public struct SerializerID: ExpressibleByIntegerLiteral, Hashable, Comparable, CustomStringConvertible, Sendable {
         public typealias IntegerLiteralType = UInt32
 
         public let value: UInt32
@@ -93,7 +93,7 @@ extension Serialization {
     ///
     /// Those messages are usually serialized using specialized serializers rather than the generic catch all Codable infrastructure,
     /// in order to allow fine grained evolution and payload size savings.
-    enum ReservedID {
+    enum ReservedID: Sendable {
         internal static let SystemMessage: SerializerID = .doNotSerialize
         internal static let SystemMessageACK: SerializerID = ._checkProtobufRepresentable(_SystemMessage.ACK.self)
         internal static let SystemMessageNACK: SerializerID = ._checkProtobufRepresentable(_SystemMessage.NACK.self)

--- a/Sources/DistributedCluster/Serialization/Serialization+Settings.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization+Settings.swift
@@ -23,7 +23,10 @@ import SwiftProtobuf
 // MARK: Serialization Settings
 
 extension Serialization {
-    public struct Settings {
+    // @unchecked Sendable: manifest2TypeRegistry stores Any.Type values (not Sendable in Swift 6),
+    // and specializedSerializerMakers returns AnySerializer (protocol, not Sendable).
+    // Settings is only mutated during system init and then treated as immutable.
+    public struct Settings: @unchecked Sendable {
         // TODO: Workaround for https://bugs.swift.org/browse/SR-12315 rdar://31838975 "Extension of nested type does not have access to types it is nested in"
         public typealias SerializerID = Serialization.SerializerID
         internal typealias ReservedID = Serialization.ReservedID

--- a/Sources/DistributedCluster/Serialization/Serialization.swift
+++ b/Sources/DistributedCluster/Serialization/Serialization.swift
@@ -326,7 +326,7 @@ extension Serialization {
     /// Container for serialization output.
     ///
     /// Describing what serializer was used to serialize the value, and its serialized bytes
-    public struct Serialized {
+    public struct Serialized: Sendable {
         public let manifest: Serialization.Manifest
         public let buffer: Serialization.Buffer
     }
@@ -334,7 +334,7 @@ extension Serialization {
     /// Abstraction of bytes containers.
     ///
     /// Designed to minimize allocation and copies when switching between different byte container types.
-    public enum Buffer {
+    public enum Buffer: Sendable {
         case data(Data)
         case nioByteBuffer(ByteBuffer)
 
@@ -660,8 +660,10 @@ extension Serialization {
 // MARK: MetaTypes so we can store Type -> Serializer mappings
 
 /// A meta type is a type eraser for any `T`, such that we can still perform `value is T` checks.
+// @unchecked Sendable: _underlying (Any.Type?) and id (ObjectIdentifier) are immutable after init.
+// Any.Type is inherently thread-safe.
 @usableFromInline
-internal struct MetaType<T>: Hashable, CustomStringConvertible {
+internal struct MetaType<T>: Hashable, CustomStringConvertible, @unchecked Sendable {
     let _underlying: Any.Type?
     let id: ObjectIdentifier
 
@@ -726,8 +728,10 @@ extension MetaType: AnyMetaType {
     }
 }
 
+// @unchecked Sendable: _ensure closure is set at init and never mutated;
+// type (Any.Type) is inherently Sendable.
 @usableFromInline
-struct SerializerTypeKey: Hashable, CustomStringConvertible {
+struct SerializerTypeKey: Hashable, CustomStringConvertible, @unchecked Sendable {
     @usableFromInline
     let type: Any.Type
     @usableFromInline
@@ -789,8 +793,12 @@ extension Foundation.Data {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Serialization: Errors
 
-public struct SerializationError: Error, CustomStringConvertible {
-    internal enum _SerializationError {
+// SerializationError is @unchecked Sendable because _Storage is a class, but it is immutable after init
+// and its _SerializationError enum captures Error values that may not be Sendable.
+public struct SerializationError: Error, CustomStringConvertible, @unchecked Sendable {
+    // @unchecked Sendable: associated Error values may not conform to Sendable,
+    // but enum values are frozen at construction time and never mutated.
+    internal enum _SerializationError: @unchecked Sendable {
         case serializationError(_: Error, file: String, line: UInt)
 
         // --- registration errors ---
@@ -834,7 +842,8 @@ public struct SerializationError: Error, CustomStringConvertible {
         case notEnoughArgumentsEncoded(expected: Int, have: Int)
     }
 
-    internal class _Storage {
+    // @unchecked Sendable: all stored properties are immutable after init (let bindings).
+    internal class _Storage: @unchecked Sendable {
         let error: _SerializationError
         let file: String
         let line: UInt

--- a/Sources/DistributedCluster/Serialization/SerializationPool.swift
+++ b/Sources/DistributedCluster/Serialization/SerializationPool.swift
@@ -131,7 +131,10 @@ public final class _SerializationPool: @unchecked Sendable {
         workerPool: AffinityThreadPool,
         task: @escaping @Sendable () throws -> Message
     ) {
-        self.enqueue(recipientPath: recipientPath, onComplete: promise.completeWith, workerPool: workerPool, task: { try task() })
+        // EventLoopPromise.completeWith is thread-safe (it dispatches to the event loop),
+        // but its function type isn't marked @Sendable. Wrap in explicit @Sendable closure.
+        nonisolated(unsafe) let promise = promise
+        self.enqueue(recipientPath: recipientPath, onComplete: { result in promise.completeWith(result) }, workerPool: workerPool, task: { try task() })
     }
 
     @inline(__always)

--- a/Sources/DistributedCluster/Serialization/SerializationPool.swift
+++ b/Sources/DistributedCluster/Serialization/SerializationPool.swift
@@ -164,16 +164,19 @@ public final class _SerializationPool: @unchecked Sendable {
 }
 
 /// Allows to "box" another value.
+// @unchecked Sendable: call closure is immutable after init and is @Sendable.
 @usableFromInline
-final class DeserializationCallback {
+final class DeserializationCallback: @unchecked Sendable {
     /// A message deserialization may either be successful or fail due to attempting to deliver at an already dead actor,
     /// if this happens, we do not *statically* have the right `Message`  to cast to and the only remaining thing for such
     /// message is to be delivered as a dead letter thus we can avoid the cast entirely.
     ///
     /// Note: resolving a dead actor yields `_ActorRef<Never>` thus we would _never_ be able to deliver the message to it,
     /// and have to special case the dead letter delivery.
+    // @unchecked Sendable: associated Any values may not conform to Sendable,
+    // but deserialized messages are only passed through the serialization pool pipeline.
     @usableFromInline
-    enum DeserializedMessage {
+    enum DeserializedMessage: @unchecked Sendable {
         case message(Any)
         case deadLetter(Any)
     }
@@ -190,7 +193,7 @@ final class DeserializationCallback {
 // MARK: Serialization.Settings
 
 /// Configure specific actor destinations to be serviced by dedicated threads in the serialization pool.
-struct SerializationPoolSettings {
+struct SerializationPoolSettings: Sendable {
     // TODO: enable configuration again, but base it on tagging actor identities
     let serializationGroups: [[ActorPath]]
 

--- a/Sources/DistributedCluster/Serialization/SerializationPool.swift
+++ b/Sources/DistributedCluster/Serialization/SerializationPool.swift
@@ -75,6 +75,9 @@ public final class _SerializationPool: @unchecked Sendable {
         recipientPath: ActorPath,
         promise: EventLoopPromise<Serialization.Serialized>
     ) {
+        // nonisolated(unsafe): message is Any which is not Sendable, but serialization closures
+        // are only executed on the serialization worker pool threads and the message is consumed once.
+        nonisolated(unsafe) let message = message
         // TODO: also record thr delay between submitting and starting serialization work here?
         self.enqueue(recipientPath: recipientPath, promise: promise, workerPool: self.serializationWorkerPool) {
             do {

--- a/Sources/DistributedCluster/Supervision.swift
+++ b/Sources/DistributedCluster/Supervision.swift
@@ -15,7 +15,7 @@
 import Logging
 
 /// Properties configuring supervision for given actor.
-internal struct _SupervisionProps {
+internal struct _SupervisionProps: @unchecked Sendable {
     // internal var supervisionMappings: [ErrorTypeIdentifier: _SupervisionStrategy]
     // on purpose stored as list, to keep order in which the supervisors are added as we "scan" from first to last when we handle
     internal var supervisionMappings: [ErrorTypeBoundSupervisionStrategy]

--- a/Sources/DistributedCluster/Supervision.swift
+++ b/Sources/DistributedCluster/Supervision.swift
@@ -409,7 +409,8 @@ extension ProcessingAction {
 /// Handles failures that may occur during message (or signal) handling within an actor.
 ///
 /// Currently not for user extension.
-internal class Supervisor<Message: Codable> {
+// @unchecked Sendable: Supervisor instances are only accessed from within the actor's mailbox run (single-threaded).
+internal class Supervisor<Message: Codable>: @unchecked Sendable {
     typealias Directive = SupervisionDirective<Message>
 
     internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, message: Message) throws -> _Behavior<Message> {
@@ -845,6 +846,7 @@ internal enum SupervisionRestartDelayedBehavior<Message: Codable> {
     @usableFromInline
     static func after(delay: Duration, with replacement: _Behavior<Message>) -> _Behavior<Message> {
         .setup { context in
+            nonisolated(unsafe) let context = context
             context.timers._startResumeTimer(key: _TimerKey("restartBackoff", isSystemTimer: true), delay: delay, resumeWith: WakeUp())
 
             return .suspend { (result: Result<WakeUp, Error>) in

--- a/Sources/DistributedCluster/Supervision.swift
+++ b/Sources/DistributedCluster/Supervision.swift
@@ -388,7 +388,7 @@ internal enum ProcessingAction<Message: Codable> {
     case message(Message)
     case signal(_Signal)
     case closure(ActorClosureCarry)
-    case continuation(() throws -> _Behavior<Message>)  // TODO: make it a Carry type for better debugging
+    case continuation(@Sendable () throws -> _Behavior<Message>)  // TODO: make it a Carry type for better debugging
     case subMessage(SubMessageCarry)
 }
 
@@ -432,7 +432,7 @@ internal class Supervisor<Message: Codable> {
         return try self.interpretSupervised0(target: target, context: context, processingAction: .subMessage(subMessage))
     }
 
-    internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, closure: @escaping () throws -> _Behavior<Message>) throws -> _Behavior<Message> {
+    internal final func interpretSupervised(target: _Behavior<Message>, context: _ActorContext<Message>, closure: @Sendable @escaping () throws -> _Behavior<Message>) throws -> _Behavior<Message> {
         traceLog_Supervision("CALLING CLOSURE: \(target)")
         return try self.interpretSupervised0(
             target: target,

--- a/Sources/DistributedCluster/Time.swift
+++ b/Sources/DistributedCluster/Time.swift
@@ -78,7 +78,7 @@ extension Duration {
 
     /// Largest time amount expressible using this type.
     /// Roughly equivalent to 292 years, which for the intents and purposes of this type can serve as "infinite".
-    static var effectivelyInfinite: Duration = .nanoseconds(Value.max)
+    static let effectivelyInfinite: Duration = .nanoseconds(Value.max)
 }
 
 extension Duration: CustomPrettyStringConvertible {

--- a/Sources/DistributedCluster/_ActorNaming.swift
+++ b/Sources/DistributedCluster/_ActorNaming.swift
@@ -58,7 +58,7 @@ extension _ActorNaming {
 
 extension _ActorNaming {
     /// Special naming scheme applied to `ask` actors.
-    static var ask: _ActorNaming = .init(unchecked: .prefixed(prefix: "$ask", suffixScheme: .letters))
+    static let ask: _ActorNaming = .init(unchecked: .prefixed(prefix: "$ask", suffixScheme: .letters))
 
     /// Naming for adapters (`context.messageAdapter`)
     static let adapter: _ActorNaming = .init(unchecked: .unique("$messageAdapter"))

--- a/Sources/DistributedCluster/_ActorNaming.swift
+++ b/Sources/DistributedCluster/_ActorNaming.swift
@@ -65,15 +65,15 @@ extension _ActorNaming {
 }
 
 /// Used while spawning actors to identify how its name should be created.
-public struct _ActorNaming: ExpressibleByStringLiteral, ExpressibleByStringInterpolation, Hashable {
+public struct _ActorNaming: ExpressibleByStringLiteral, ExpressibleByStringInterpolation, Hashable, Sendable {
     // We keep an internal enum, but do not expose it as we may want to add more naming strategies in the future?
-    internal enum _Naming: Hashable {
+    internal enum _Naming: Hashable, Sendable {
         case unique(String)
         // case uniqueNumeric(NumberingScheme)
         case prefixed(prefix: String, suffixScheme: SuffixScheme)
     }
 
-    internal enum SuffixScheme {
+    internal enum SuffixScheme: Sendable {
         /// Scheme optimized for sequential related to each other entities, such as workers, or process identifiers.
         /// resulting in sequential numeric values: `1, 2, 3, ..., 9, 10, 11, 12, ...`
         ///

--- a/Sources/DistributedCluster/_ActorShell.swift
+++ b/Sources/DistributedCluster/_ActorShell.swift
@@ -512,6 +512,7 @@ public final class _ActorShell<Message: Codable>: _ActorContext<Message>, Abstra
     internal func interpretResume(_ result: Result<Any, Error>) throws -> ActorRunResult {
         switch self.behavior.underlying {
         case .suspended(let previousBehavior, let handler):
+            nonisolated(unsafe) let result = result
             let next = try self.supervisor.interpretSupervised(target: previousBehavior, context: self) {
                 try handler(result)
             }

--- a/Sources/DistributedCluster/_ActorShell.swift
+++ b/Sources/DistributedCluster/_ActorShell.swift
@@ -29,7 +29,9 @@ import NIO
 ///
 /// The shell is mutable, and full of dangerous and carefully threaded/ordered code, be extra cautious.
 // TODO: remove this and replace by the infrastructure which is now Swift's `actor`
-public final class _ActorShell<Message: Codable>: _ActorContext<Message>, AbstractShellProtocol {
+// @unchecked Sendable: Legacy C mailbox runtime. This type is planned for removal
+// when _ActorShell is replaced with Swift's native actor runtime. See GitHub issue #5.
+public final class _ActorShell<Message: Codable>: _ActorContext<Message>, AbstractShellProtocol, @unchecked Sendable {
     // The phrase that "actor change their behavior" can be understood quite literally;
     // On each message interpretation the actor may return a new behavior that will be handling the next message.
     @usableFromInline

--- a/Sources/DistributedCluster/_BehaviorTimers.swift
+++ b/Sources/DistributedCluster/_BehaviorTimers.swift
@@ -48,7 +48,7 @@ struct TimerEvent {
 ///     timers.cancelTimer(forKey: timerKey)
 ///
 // TODO: replace timers with AsyncTimerSequence from swift-async-algorithms
-internal struct _TimerKey: Hashable {
+internal struct _TimerKey: Hashable, @unchecked Sendable {
     private let identifier: AnyHashable
 
     @usableFromInline

--- a/Sources/DistributedCluster/_BehaviorTimers.swift
+++ b/Sources/DistributedCluster/_BehaviorTimers.swift
@@ -80,12 +80,16 @@ extension _TimerKey: ExpressibleByStringLiteral, ExpressibleByStringInterpolatio
     }
 }
 
-public final class _BehaviorTimers<Message: Codable> {
+// @unchecked Sendable: Legacy C mailbox runtime. This type is planned for removal
+// when _ActorShell is replaced with Swift's native actor runtime. See GitHub issue #5.
+public final class _BehaviorTimers<Message: Codable>: @unchecked Sendable {
     @usableFromInline
     internal var timerGen: Int = 0
 
     // TODO: eventually replace with our own scheduler implementation
     @usableFromInline
+    // MIGRATION NOTE: DispatchQueue usage will be eliminated when this class is replaced with
+    // a Swift actor. See GitHub issue #5.
     internal let dispatchQueue = DispatchQueue.global()
     internal var installedTimers: [_TimerKey: Timer<Message>] = [:]
     @usableFromInline

--- a/Sources/DistributedCluster/_Mailbox.swift
+++ b/Sources/DistributedCluster/_Mailbox.swift
@@ -56,7 +56,9 @@ internal enum MailboxBitMasks {
     //                           = 0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0001_1101
 }
 
-internal final class _Mailbox<Message: Codable> {
+// @unchecked Sendable: Legacy C mailbox runtime. This type is planned for removal
+// when _ActorShell is replaced with Swift's native actor runtime. See GitHub issue #5.
+internal final class _Mailbox<Message: Codable>: @unchecked Sendable {
     weak var shell: _ActorShell<Message>?
     let _status: ManagedAtomic<UInt64> = .init(0)
     let userMessages: MPSCLinkedQueue<Payload>

--- a/Sources/DistributedCluster/_Signals.swift
+++ b/Sources/DistributedCluster/_Signals.swift
@@ -144,7 +144,7 @@ public enum _Signals {
     ///         you may choose to handle all `Terminated` signals the same way.
     ///
     /// - SeeAlso: `Terminated` which is sent when a watched actor terminates.
-    final class _ChildTerminated: Terminated {
+    final class _ChildTerminated: Terminated, @unchecked Sendable {
         /// Filled with the error that caused the child actor to terminate.
         /// This kind of information is only known to the parent, which may decide to perform
         /// some action based on the error, i.e. proactively stop other children or spawn another worker


### PR DESCRIPTION
chore: Make ActorMetadata @unchecked Sendable, migrate DispatchSemaphore to Lock (Phase 2)

Replace DispatchSemaphore with pthread-based Lock from DistributedActorsConcurrencyHelpers
for consistent lock discipline across the codebase. Document the synchronization strategy
in the class doc comment.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: Document Sendable story for ClusterShell and ClusterShellState (Phase 2)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: Audit ClusterSystem for Swift 6 Sendable compliance, document lock protocol (Phase 2)

Document the 5-lock discipline that underpins @unchecked Sendable:
- namingLock guards naming context and actor registries
- initLock guards lazy subsystem initialization
- lazyInitializationLock guards serialization
- inFlightCallLock guards remote call continuations
- shutdownSemaphore guards shutdown sequencing

Add nonisolated to isShuttingDown/isTerminated (atomic-backed).
Add FIXME markers for set-once fields lacking formal lock protection.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: Document Sendable story for NIO transport handlers and Association (Phase 2)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: Document _ActorShell as planned-removal, add Swift 6 annotations (Phase 2)

Mark _ActorShell, _Mailbox, _Children, and _BehaviorTimers as @unchecked Sendable
with documentation pointing to GitHub issue #5 for full replacement with Swift
native actor runtime.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: Receptionist, Gossip, Behaviors Sendable audit (Phase 2)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: Fix Protobuf defaultInstance and static globals for Swift 6 (Phase 3)

- Add nonisolated(unsafe) to Protobuf _StorageClass defaultInstance properties
- Convert static var to static let where values are constant
- Add nonisolated(unsafe) to genuinely mutable static vars

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

chore: Make Serialization inner types Sendable (Phase 3)

- Add Sendable to SerializerID, Buffer, Manifest, Serialized value types
- Add Sendable to Serialization.Context (all stored properties are Sendable)
- Add @unchecked Sendable to Settings (Any.Type and AnySerializer not Sendable)
- Add @unchecked Sendable to SerializationError and WorkerPoolError (class storage)
- Add @unchecked Sendable to MetaType, SerializerTypeKey (Any.Type, closures)
- Add @unchecked Sendable to DeserializationCallback (immutable class with @Sendable closure)
- Add Sendable to SerializationPoolSettings, ReservedID
- Document lock discipline for all @unchecked Sendable types

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

chore: Add @Sendable to behavior closures and supervision continuations (Phase 3)

- Make __Behavior enum closure cases @Sendable (setup, receive, receiveMessage,
  signalHandling, suspend, suspended)
- Add @Sendable to _Behavior factory method parameters (receive, receiveMessage,
  setup, stop, receiveSignal, receiveSpecificSignal, signalHandling, suspend,
  suspended)
- Add @Sendable to ProcessingAction.continuation closure in Supervision
- Add @Sendable to Supervisor.interpretSupervised closure parameter
- Normalize @Sendable @escaping ordering across all declarations

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

chore: Fix remaining type conformances for Swift 6 (Phase 3)

- Fix @retroactive on in-module Cancelable protocol conformance
- Remove redundant DispatchQueue Sendable conformance
- Add Sendable to serialization types (Buffer, Manifest, SerializerID, Serialized)
- Add @unchecked Sendable to _AddressableActorRef and MembershipChange
- Restate inherited @unchecked Sendable on _ReceptionistMessage subclasses
- Restate inherited @unchecked Sendable on _ChildTerminated
- Fix non-Sendable metatype capture in ClusterSingletonBoss interceptor
- Fix non-Sendable function conversion in SerializationPool

All "error in Swift 6 language mode" warnings are now resolved.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

chore: Fix closure captures and local function Sendable annotations (Phase 3)

- Add @Sendable to local functions used in behavior closures
- Add @unchecked Sendable to types captured as self in @Sendable closures
- Use nonisolated(unsafe) for runtime-safe captures in actor mailbox closures

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

chore: Flip DistributedCluster to .v6, fix type conformances and static properties (Phase 3)

- Flip DistributedCluster swiftLanguageMode from .v5 to .v6
- Add Sendable to settings types, event types, error types
- Add @unchecked Sendable where thread safety is manually managed
- Fix static property concurrency safety

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

chore: Fix final closure captures and sending diagnostics for Swift 6 (Phase 3)

- Add nonisolated(unsafe) for non-Sendable captures in @Sendable closures
- Use @Sendable local variable pattern for Task/addTask sending parameters
- Fix SWIM.Settings actor isolation escape
- Fix ClusterSingletonBoss distributed actor capture patterns

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

- Resolves #
- _[After your change, what will change.]_
